### PR TITLE
Added option to autorun certain commands on file actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
 					"default": false,
 					"description": "Automatically open a file for edit when saved"
 				},
+				"perforce.editOnFileModified": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically open a file for edit when Modified"
+				},
 				"perforce.addOnFileCreate": {
 					"type": "boolean",
 					"default": false,

--- a/package.json
+++ b/package.json
@@ -30,15 +30,30 @@
 	],
 	"main": "./perforce",
 	"activationEvents": [
-		"onCommand:perforce.menuFunctions",
-		"onCommand:perforce.showOutput",
-		"onCommand:perforce.add",
-		"onCommand:perforce.edit",
-		"onCommand:perforce.revert",
-		"onCommand:perforce.diff",
-		"onCommand:perforce.info"
+		"*"
 	],
 	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "VS Code Perforce Configuration",
+			"properties": {
+				"perforce.editOnFileSave": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically open a file for edit when saved"
+				},
+				"perforce.addOnFileCreate": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically Add a file to depot when Created"
+				},
+				"perforce.deleteOnFileDelete": {
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically delete a file from depot when deleted"
+				}
+			}
+		},
 		"commands": [
 			{
 				"command": "perforce.menuFunctions",

--- a/perforce.js
+++ b/perforce.js
@@ -206,7 +206,6 @@ function p_deleteUri(uri) {
 	
 	_channel.appendLine(cmdline);
 	CP.exec(cmdline, {cwd: workspace.rootPath}, function (err, stdout, stderr) {
-		console.log(stdout, stderr, err);
 		if(err){
 			_channel.show();
 			_channel.appendLine("ERROR:");
@@ -280,10 +279,20 @@ function w_onFileSaved(doc) {
 }
 
 function w_onFileDeleted(uri) {
+	if (workspace.rootPath == undefined){
+		window.showInformationMessage("Perforce: no folder opened");
+		return;
+	}
+	
 	p_deleteUri(uri);
 }
 
 function w_onFileCreated(uri) {
+	if (workspace.rootPath == undefined){
+		window.showInformationMessage("Perforce: no folder opened");
+		return;
+	}
+	
 	var editor = window.activeTextEditor;
 	//Only add files open in text editor
 	if(editor.document && editor.document.uri.fsPath == uri.fsPath) {

--- a/perforce.js
+++ b/perforce.js
@@ -6,6 +6,9 @@ var workspace = vscode.workspace;
 var isWin = /^win/.test(process.platform);
 var _channel = window.createOutputChannel('Perforce Log');
 
+var _subscriptions = [];
+var _watcher = null;
+
 function activate() {
 	_channel.appendLine("Perforce Log Output");
 	
@@ -16,6 +19,25 @@ function activate() {
 	vscode.commands.registerCommand('perforce.diff', p_diff);
 	vscode.commands.registerCommand('perforce.info', p_info);
 	vscode.commands.registerCommand('perforce.menuFunctions', p_menuFunction);
+	
+	var config = workspace.getConfiguration('perforce');
+	
+	if(config) { 
+		if(config.editOnFileSave) {
+			workspace.onDidSaveTextDocument(w_onFileSaved, this, _subscriptions);
+		}
+		if(config.deleteOnFileDelete || config.addOnFileCreate) {
+			_watcher = workspace.createFileSystemWatcher('**/*.*', false, true, false);
+			
+			if(config.deleteOnFileDelete) {
+				_watcher.onDidDelete(w_onFileDeleted);
+			}
+			
+			if(config.addOnFileCreate) {
+				_watcher.onDidCreate(w_onFileCreated);
+			}
+		}
+	}
 }
 exports.activate = activate;
 
@@ -49,6 +71,10 @@ function p_add() {
 		return;
 	}
 	var uri = editor.document.uri;
+	p_addUri(uri);
+}
+
+function p_addUri(uri) {
 	var cmdline = buildCmdline("add", '"' + uri.fsPath + '"');
 	
 	_channel.appendLine(cmdline);
@@ -75,7 +101,11 @@ function p_edit() {
 		window.showInformationMessage("Perforce: no folder opened");
 		return;
 	}
-	var uri = editor.document.uri;
+	
+	p_editUri(editor.document.uri);
+}
+
+function p_editUri(uri) {
 	var cmdline = buildCmdline("edit", '"' + uri.fsPath + '"');
 	
 	_channel.appendLine(cmdline);
@@ -174,6 +204,24 @@ function p_info() {
 	});
 }
 
+function p_deleteUri(uri) {
+	var cmdline = buildCmdline("delete", '"' + uri.fsPath + '"');
+	
+	_channel.appendLine(cmdline);
+	CP.exec(cmdline, {cwd: workspace.rootPath}, function (err, stdout, stderr) {
+		console.log(stdout, stderr, err);
+		if(err){
+			_channel.show();
+			_channel.appendLine("ERROR:");
+			_channel.append(stderr.toString());
+		}
+		else {
+			window.showInformationMessage("Perforce: file marked for delete");
+			_channel.append(stdout.toString());
+		}
+	});
+}
+
 function p_menuFunction() {
 	var items = [];
 	items.push({ label: "add", description: "Open a new file to add it to the depot" });
@@ -204,4 +252,44 @@ function p_menuFunction() {
 				break;
 		}
 	});
+}
+
+function p_checkFileOpened(uri, onSuccess) {
+	var cmdline = buildCmdline("opened", '"' + uri.fsPath + '"');
+	
+	_channel.appendLine(cmdline);
+	CP.exec(cmdline, {cwd: workspace.rootPath}, function (err, stdout, stderr) {
+		if(err){
+			_channel.show();
+			_channel.appendLine("ERROR:");
+			_channel.append(stderr.toString());
+		}
+		else {
+			//stderr set if not opened
+			if(stderr) {
+				onSuccess(uri);
+			}
+			_channel.append(stdout.toString());
+		}
+	});
+	
+	return true;
+}
+
+function w_onFileSaved(doc) {
+	p_checkFileOpened(doc.uri, function(uri) {
+		p_editUri(uri);
+	});
+}
+
+function w_onFileDeleted(uri) {
+	p_deleteUri(uri);
+}
+
+function w_onFileCreated(uri) {
+	var editor = window.activeTextEditor;
+	//Only add files open in text editor
+	if(editor.document && editor.document.uri.fsPath == uri.fsPath) {
+		p_addUri(uri);
+	}
 }


### PR DESCRIPTION
Runs:
edit on file save
add on file create
delete on file delete
These are all behind configuration options and disabled by default. Highly experimental.

Note some significant changes:
Activates the plugin on VSCode launch now, however will only apply listeners if the respective options are enabled.

Not very thoroughly tested so probably many edge cases. Very experimental.

Also sucks that VSCode doesnt have a presave hook so you have to choose "overwrite" when saving an existing file the first time if write protected.