### PR TITLE
Fixed the opened files regexp to also match files that have type modifiers

### DIFF
--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -381,7 +381,7 @@ export class Model implements Disposable {
 
         const files = [];
         opened.forEach(open => {
-            const matches = open.match(/(.+)#(\d+)\s-\s([\w\/]+)\s(default\schange|change\s\d+)\s\((\w+)\)/);
+            const matches = open.match(/(.+)#(\d+)\s-\s([\w\/]+)\s(default\schange|change\s\d+)\s\(([\w\+]+)\)/);
             if (matches) {
                 files.push(matches[1]);
             }


### PR DESCRIPTION
I noticed some files didn't appear in the vscode-perforce changelists. This was happening because the opened files are checked against a regexp which was discarding some of the output.

Example from `p4 opened`:
"//depot/path/to/a/script.sh#99 - edit default change (text+x)"

This was discarded because `text+x` doesn't match to `\w`. Replaced `\w` with `[\w\+]+`.

Perforce docs for type modifiers: https://www.perforce.com/perforce/doc.current/manuals/cmdref/file.types.html