### PR TITLE
modify FileSystemWatcher to ignore files in config.files.exclude or .p4ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,7 +444,9 @@
     ]
   },
   "dependencies":{
-    "tmp":"0.0.28"
+    "tmp":"0.0.28",
+    "micromatch":"^2.3.11",
+    "parse-gitignore":"^0.4.0"
   },
   "devDependencies":{
     "vscode":"^1.0.0",

--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -12,6 +12,7 @@ import {
 
 import * as micromatch from 'micromatch';
 import * as parseignore from 'parse-gitignore';
+import * as process from 'process';
 
 import {Display} from './Display';
 import {PerforceCommands} from './PerforceCommands';
@@ -56,7 +57,9 @@ export default class FileSystemListener
         }
 
         this._p4ignore = [];
-        workspace.findFiles('.p4ignore', null, 1).then((result) => {
+
+        const p4IgnoreFileName = process.env.P4IGNORE ? process.env.P4IGNORE : '.p4ignore';
+        workspace.findFiles(p4IgnoreFileName, null, 1).then((result) => {
             if (result.length > 0) {
                 this._p4ignore = parseignore(result[0].fsPath);
             }


### PR DESCRIPTION
Should fix #27 and is a good workaround for #62.

Note: this doesn't support multiple file names in P4IGNORE.