### PR TITLE
fixed activation of the extension

### DIFF
--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -12,7 +12,6 @@ import {
 
 import * as micromatch from 'micromatch';
 import * as parseignore from 'parse-gitignore';
-import * as process from 'process';
 
 import {Display} from './Display';
 import {PerforceCommands} from './PerforceCommands';


### PR DESCRIPTION
I noticed my last change was causing an error when debugging the extension:
```
Here is the error stack:  /home/ihalip/projects/vscode-perforce/out/src/FileSystemListener.js:6
const process = require("process");
                                 ^
SyntaxError: Identifier 'process' has already been declared
```

This should fix it.