### PR TITLE
Change extension category to `SCM Providers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher":"slevesque",
   "license":"LICENSE.md",
   "categories":[
-    "Other"
+    "SCM Providers"
   ],
   "icon":"icon.png",
   "bugs":{


### PR DESCRIPTION
VSCode could automatically drive users to discover new SCM Providers in the Marketplace. For this, we need the extensions to have the correct category.

Related to Microsoft/vscode#25696