### PR TITLE
Crash fix

### DIFF
--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -59,7 +59,7 @@ export default class FileSystemListener
 
         const p4IgnoreFileName = process.env.P4IGNORE ? process.env.P4IGNORE : '.p4ignore';
         workspace.findFiles(p4IgnoreFileName, null, 1).then((result) => {
-            if (result.length > 0) {
+            if (result && result.length > 0) {
                 this._p4ignore = parseignore(result[0].fsPath);
             }
         });

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -7,7 +7,7 @@ import {
     Uri
 } from 'vscode';
 
-import { DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
+import { ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
 
 
 import * as Path from 'path';
@@ -124,7 +124,7 @@ export namespace PerforceCommands
                 if(!err) {
                     Display.showError("file opened for edit");
                 }
-                resolve(err);
+                reject(err);
             }, args, directoryOverride);
         });
     }
@@ -265,15 +265,16 @@ export namespace PerforceCommands
                     colorIndex = (colorIndex + 1) % decorateColors.length
                 }
 
+                const before: ThemableDecorationAttachmentRenderOptions = {
+                    contentText: (cl ? '' : '#') + num,
+                    color: decorateColors[colorIndex]
+                };
+                const renderOptions: DecorationInstanceRenderOptions = { before };
+
                 decorations.push({
                     range: new Range(i, 0, i, 0),
                     hoverMessage,
-                    renderOptions: {
-                        before: {
-                            color: decorateColors[colorIndex],
-                            contentText: (cl ? '' : '#') + num
-                        } as DecorationInstanceRenderOptions
-                    }
+                    renderOptions
                 });
 
             }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -71,7 +71,7 @@ export namespace Utils
                 } else if (stderr) {
                     reject(stderr);
                 } else {
-                    resolve(stdout);
+                    resolve(true);
                 }
             }, '-s');
         });


### PR DESCRIPTION
based on previous pull request 'compile fixes'

extension crashed when loading vscode with no folder opened (ie, first debug load of extension debugging)