### PR TITLE
Feature submitdefault

### DIFF
--- a/package.json
+++ b/package.json
@@ -504,6 +504,10 @@
       {
         "key":"alt+p o",
         "command":"perforce.opened"
+      },
+      {
+        "key":"alt+p s",
+        "command":"perforce.submitDefault"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
       },
       {
         "command": "perforce.submitDefault",
-        "title": "Submit default",
+        "title": "Submit Default Changelist",
         "category": "Perforce",
         "icon": {
           "light": "resources/icons/light/submit.svg",
@@ -367,6 +367,11 @@
       ],
       "scm/resourceGroup/context": [
         {
+          "command": "perforce.submitDefault",
+          "when": "scmProvider == perforce && scmResourceGroup == default",
+          "group": "inline@1"
+        },
+        {
           "command": "perforce.submitChangelist",
           "when": "scmProvider == perforce && scmResourceGroup != default",
           "group": "inline@1"
@@ -380,6 +385,11 @@
           "command": "perforce.editChangelist",
           "when": "scmProvider == perforce",
           "group": "inline@3"
+        },
+        {
+          "command": "perforce.submitDefault",
+          "when": "scmProvider == perforce && scmResourceGroup == default",
+          "group": "1_modification@1"
         },
         {
           "command": "perforce.submitChangelist",

--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -59,7 +59,7 @@ export default class FileSystemListener
 
         const p4IgnoreFileName = process.env.P4IGNORE ? process.env.P4IGNORE : '.p4ignore';
         workspace.findFiles(p4IgnoreFileName, null, 1).then((result) => {
-            if (result.length > 0) {
+            if (result && result.length > 0) {
                 this._p4ignore = parseignore(result[0].fsPath);
             }
         });

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -428,6 +428,7 @@ export namespace PerforceCommands
         items.push({ label: "add", description: "Open a new file to add it to the depot" });
         items.push({ label: "edit", description: "Open an existing file for edit" });
         items.push({ label: "revert", description: "Discard changes from an opened file" });
+        items.push({ label: "submitDefault", description: "Submit or Save the default changelist" });
         items.push({ label: "diff", description: "Display diff of client file with depot file" });
         items.push({ label: "diffRevision", description: "Display diff of client file with depot file at a specific revision" });
         items.push({ label: "annotate", description: "Print file lines and their revisions" });
@@ -447,6 +448,9 @@ export namespace PerforceCommands
                     break;
                 case "revert":
                     revert();
+                    break;
+                case "submitDefault":
+                    PerforceSCMProvider.SubmitDefault();
                     break;
                 case "diff":
                     diff();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -48,7 +48,7 @@ export namespace PerforceCommands
             PerforceSCMProvider.Open(e);
         });
         commands.registerCommand('perforce.submitDefault', () => {
-            PerforceSCMProvider.Submit();
+            PerforceSCMProvider.SubmitDefault();
         });
         commands.registerCommand('perforce.processChangelist', () => {
             PerforceSCMProvider.ProcessChangelist();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -7,7 +7,7 @@ import {
     Uri
 } from 'vscode';
 
-import { DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
+import { ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
 
 
 import * as Path from 'path';
@@ -124,7 +124,7 @@ export namespace PerforceCommands
                 if(!err) {
                     Display.showError("file opened for edit");
                 }
-                resolve(err);
+                reject(err);
             }, args, directoryOverride);
         });
     }
@@ -265,15 +265,16 @@ export namespace PerforceCommands
                     colorIndex = (colorIndex + 1) % decorateColors.length
                 }
 
+                const before: ThemableDecorationAttachmentRenderOptions = {
+                    contentText: (cl ? '' : '#') + num,
+                    color: decorateColors[colorIndex]
+                };
+                const renderOptions: DecorationInstanceRenderOptions = { before };
+
                 decorations.push({
                     range: new Range(i, 0, i, 0),
                     hoverMessage,
-                    renderOptions: {
-                        before: {
-                            color: decorateColors[colorIndex],
-                            contentText: (cl ? '' : '#') + num
-                        } as DecorationInstanceRenderOptions
-                    }
+                    renderOptions
                 });
 
             }

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -124,6 +124,12 @@ export class PerforceSCMProvider {
         await perforceProvider._model.Describe(input);
     };
 
+    public static async SubmitDefault(): Promise<void> {
+        const perforceProvider: PerforceSCMProvider = PerforceSCMProvider.GetInstance();
+
+        await perforceProvider._model.SubmitDefault();
+    };
+    
     public static async Submit(input?: Resource | SourceControlResourceGroup): Promise<void> {
         const perforceProvider: PerforceSCMProvider = PerforceSCMProvider.GetInstance();
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -71,7 +71,7 @@ export namespace Utils
                 } else if (stderr) {
                     reject(stderr);
                 } else {
-                    resolve(stdout);
+                    resolve(true);
                 }
             }, '-s');
         });

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -183,7 +183,7 @@ export class Model implements Disposable {
         const descStr = await vscode.window.showInputBox({
             placeHolder: 'New changelist description',
             validateInput: (value: string) => {
-                if (!value || value.length === 0) {
+                if (!value || value.trim().length === 0) {
                     return 'Cannot set empty description';
                 }
                 return null;
@@ -191,7 +191,9 @@ export class Model implements Disposable {
             ignoreFocusOut: true
         });
 
-        if (descStr === undefined) {
+        if (descStr === undefined || descStr.trim().length == 0) {
+            // pressing enter with no other input will still submit the empty string
+            Display.showError('Cannot set empty description');
             return;
         }
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -172,6 +172,7 @@ export class Model implements Disposable {
             }
         } catch (err) {
             Display.showError(err.toString());
+            return;
         }
 
 


### PR DESCRIPTION
based on previous pull requests 'compile fixes' and 'crash fix'

implementation and associated fixes for submitting the default changelist, or saving to another cl

note that it currently does not allow an empty description (this could easily be made into a config, but I feel this is appropriate default behavior.  todo: make the config a validity regex)

to activate: keybinding alt-p s; right click the default changelist; click the checkmark; alt-p space -> submitDefault; ctrl-p > perforce default  ... etc

enter the description (or cancel)
select Submit or Save Changelist (or cancel)
magic happens