### PR TITLE
Feature .p4config && p4dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-  "name":"perforce",
-  "displayName":"Perforce for VS Code",
-  "description":"Perforce integration with VS Code's SCM features",
-  "version":"2.1.1",
-  "publisher":"slevesque",
-  "license":"LICENSE.md",
-  "categories":[
+  "name": "perforce",
+  "displayName": "Perforce for VS Code",
+  "description": "Perforce integration with VS Code's SCM features",
+  "version": "2.1.1",
+  "publisher": "slevesque",
+  "license": "LICENSE.md",
+  "categories": [
     "SCM Providers"
   ],
-  "icon":"icon.png",
-  "bugs":{
-    "url":"https://github.com/stef-levesque/vscode-perforce/issues"
+  "icon": "icon.png",
+  "bugs": {
+    "url": "https://github.com/stef-levesque/vscode-perforce/issues"
   },
-  "homepage":"https://github.com/stef-levesque/vscode-perforce/blob/master/README.md",
-  "repository":{
-    "type":"git",
-    "url":"https://github.com/stef-levesque/vscode-perforce.git"
+  "homepage": "https://github.com/stef-levesque/vscode-perforce/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stef-levesque/vscode-perforce.git"
   },
-  "galleryBanner":{
-    "color":"#5c2d91",
-    "theme":"dark"
+  "galleryBanner": {
+    "color": "#5c2d91",
+    "theme": "dark"
   },
-  "engines":{
-    "vscode":"^1.12.1"
+  "engines": {
+    "vscode": "^1.12.1"
   },
   "enableProposedApi": false,
-  "keywords":[
+  "keywords": [
     "vscode",
     "scm",
     "perforce",
     "sourcedepot"
   ],
-  "main":"./out/src/extension",
-  "activationEvents":[
+  "main": "./out/src/extension",
+  "activationEvents": [
     "*"
   ],
-  "contributes":{
-    "configuration":{
-      "type":"object",
-      "title":"VS Code Perforce Configuration",
-      "properties":{
-        "perforce.editOnFileSave":{
-          "type":"boolean",
-          "default":false,
-          "description":"Automatically open a file for edit when saved"
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "VS Code Perforce Configuration",
+      "properties": {
+        "perforce.editOnFileSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically open a file for edit when saved"
         },
-        "perforce.editOnFileModified":{
-          "type":"boolean",
-          "default":false,
-          "description":"Automatically open a file for edit when Modified"
+        "perforce.editOnFileModified": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically open a file for edit when Modified"
         },
-        "perforce.addOnFileCreate":{
-          "type":"boolean",
-          "default":false,
-          "description":"Automatically Add a file to depot when Created"
+        "perforce.addOnFileCreate": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically Add a file to depot when Created"
         },
-        "perforce.deleteOnFileDelete":{
-          "type":"boolean",
-          "default":false,
-          "description":"Automatically delete a file from depot when deleted"
+        "perforce.deleteOnFileDelete": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically delete a file from depot when deleted"
         },
         "perforce.annotate.changelist": {
           "type": "boolean",
@@ -75,12 +75,12 @@
           "default": false,
           "description": "Show annotation for every file"
         },
-        "perforce.client":{
+        "perforce.client": {
           "type": "string",
           "default": "none",
           "description": "Overrides any P4CLIENT setting with the specified client name"
         },
-        "perforce.user":{
+        "perforce.user": {
           "type": "string",
           "default": "none",
           "description": "Overrides any P4USER, USER, or USERNAME setting with the specified user name"
@@ -100,7 +100,7 @@
           "default": "none",
           "description": "Overrides any PWD setting (current working directory) and replaces it with the specified directory"
         },
-        "perforce.command":{
+        "perforce.command": {
           "type": "string",
           "default": "none",
           "description": "Configure a path to p4 or an alternate command if needed"
@@ -109,8 +109,8 @@
           "type": "string",
           "default": "perforce",
           "enum": [
-              "perforce",
-              "sourcedepot"
+            "perforce",
+            "sourcedepot"
           ],
           "description": "Specify if we should run in compatibility mode, currently support 'perforce' and 'sourcedepot'"
         },
@@ -160,16 +160,16 @@
         }
       }
     },
-    "commands":[
+    "commands": [
       {
-        "command":"perforce.menuFunctions",
-        "title":"Show Perforce functions",
-        "category":"Perforce"
+        "command": "perforce.menuFunctions",
+        "title": "Show Perforce functions",
+        "category": "Perforce"
       },
       {
-        "command":"perforce.showOutput",
-        "title":"Show Output",
-        "category":"Perforce"
+        "command": "perforce.showOutput",
+        "title": "Show Output",
+        "category": "Perforce"
       },
       {
         "command": "perforce.login",
@@ -182,29 +182,29 @@
         "category": "Perforce"
       },
       {
-        "command":"perforce.add",
-        "title":"add - Open a new file to add it to the depot",
-        "category":"Perforce"
+        "command": "perforce.add",
+        "title": "add - Open a new file to add it to the depot",
+        "category": "Perforce"
       },
       {
-        "command":"perforce.edit",
-        "title":"edit - Open an existing file for edit",
-        "category":"Perforce"
+        "command": "perforce.edit",
+        "title": "edit - Open an existing file for edit",
+        "category": "Perforce"
       },
       {
-        "command":"perforce.revert",
-        "title":"revert - Discard changes from an opened file",
-        "category":"Perforce"
+        "command": "perforce.revert",
+        "title": "revert - Discard changes from an opened file",
+        "category": "Perforce"
       },
       {
-        "command":"perforce.diff",
-        "title":"diff - Display diff of client file with depot file",
-        "category":"Perforce"
+        "command": "perforce.diff",
+        "title": "diff - Display diff of client file with depot file",
+        "category": "Perforce"
       },
       {
-        "command":"perforce.diffRevision",
-        "title":"diff revision - Display diff of client file with depot file at a specific revision",
-        "category":"Perforce"
+        "command": "perforce.diffRevision",
+        "title": "diff revision - Display diff of client file with depot file at a specific revision",
+        "category": "Perforce"
       },
       {
         "command": "perforce.annotate",
@@ -212,9 +212,9 @@
         "category": "Perforce"
       },
       {
-        "command":"perforce.info",
-        "title":"Display client/server information",
-        "category":"Perforce",
+        "command": "perforce.info",
+        "title": "Display client/server information",
+        "category": "Perforce",
         "icon": {
           "light": "resources/icons/light/p4.svg",
           "dark": "resources/icons/dark/p4.svg"
@@ -317,9 +317,9 @@
         }
       },
       {
-        "command":"perforce.opened",
-        "title":"opened - Display 'open' files and open one in the editor",
-        "category":"Perforce"
+        "command": "perforce.opened",
+        "title": "opened - Display 'open' files and open one in the editor",
+        "category": "Perforce"
       }
     ],
     "menus": {
@@ -455,14 +455,14 @@
         }
       ]
     },
-    "keybindings":[
+    "keybindings": [
       {
-        "key":"alt+p space",
-        "command":"perforce.menuFunctions"
+        "key": "alt+p space",
+        "command": "perforce.menuFunctions"
       },
       {
-        "key":"alt+p l",
-        "command":"perforce.showOutput"
+        "key": "alt+p l",
+        "command": "perforce.showOutput"
       },
       {
         "key": "alt+p enter",
@@ -473,24 +473,24 @@
         "command": "perforce.logout"
       },
       {
-        "key":"alt+p a",
-        "command":"perforce.add",
-        "when":"editorTextFocus"
+        "key": "alt+p a",
+        "command": "perforce.add",
+        "when": "editorTextFocus"
       },
       {
-        "key":"alt+p e",
-        "command":"perforce.edit",
-        "when":"editorTextFocus"
+        "key": "alt+p e",
+        "command": "perforce.edit",
+        "when": "editorTextFocus"
       },
       {
-        "key":"alt+p r",
-        "command":"perforce.revert",
-        "when":"editorTextFocus"
+        "key": "alt+p r",
+        "command": "perforce.revert",
+        "when": "editorTextFocus"
       },
       {
-        "key":"alt+p d",
-        "command":"perforce.diff",
-        "when":"editorTextFocus"
+        "key": "alt+p d",
+        "command": "perforce.diff",
+        "when": "editorTextFocus"
       },
       {
         "key": "alt+p n",
@@ -498,32 +498,33 @@
         "when": "editorTextFocus"
       },
       {
-        "key":"alt+p i",
-        "command":"perforce.info"
+        "key": "alt+p i",
+        "command": "perforce.info"
       },
       {
-        "key":"alt+p o",
-        "command":"perforce.opened"
+        "key": "alt+p o",
+        "command": "perforce.opened"
       },
       {
-        "key":"alt+p s",
-        "command":"perforce.submitDefault"
+        "key": "alt+p s",
+        "command": "perforce.submitDefault"
       }
     ]
   },
-  "dependencies":{
-    "tmp":"^0.0.31",
-    "micromatch":"^3.0.3",
-    "parse-gitignore":"^0.4.0"
+  "dependencies": {
+    "tmp": "^0.0.31",
+    "ini": "^1.3.4",
+    "micromatch": "^3.0.3",
+    "parse-gitignore": "^0.4.0"
   },
-  "devDependencies":{
-    "vscode":"^1.0.0",
-    "@types/node":"^8.0.8",
-    "typescript":"^2.0.3"
+  "devDependencies": {
+    "vscode": "^1.1.5",
+    "@types/node": "^8.0.8",
+    "typescript": "^2.0.3"
   },
-  "scripts":{
-    "vscode:prepublish":"tsc -p ./",
-    "compile":"tsc -watch -p ./",
-    "postinstall":"node ./node_modules/vscode/bin/install"
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
   }
 }

--- a/package.json
+++ b/package.json
@@ -504,6 +504,10 @@
       {
         "key":"alt+p o",
         "command":"perforce.opened"
+      },
+      {
+        "key":"alt+p s",
+        "command":"perforce.submitDefault"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
       },
       {
         "command": "perforce.submitDefault",
-        "title": "Submit default",
+        "title": "Submit Default Changelist",
         "category": "Perforce",
         "icon": {
           "light": "resources/icons/light/submit.svg",
@@ -367,6 +367,11 @@
       ],
       "scm/resourceGroup/context": [
         {
+          "command": "perforce.submitDefault",
+          "when": "scmProvider == perforce && scmResourceGroup == default",
+          "group": "inline@1"
+        },
+        {
           "command": "perforce.submitChangelist",
           "when": "scmProvider == perforce && scmResourceGroup != default",
           "group": "inline@1"
@@ -380,6 +385,11 @@
           "command": "perforce.editChangelist",
           "when": "scmProvider == perforce",
           "group": "inline@3"
+        },
+        {
+          "command": "perforce.submitDefault",
+          "when": "scmProvider == perforce && scmResourceGroup == default",
+          "group": "1_modification@1"
         },
         {
           "command": "perforce.submitChangelist",

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -34,7 +34,7 @@ export namespace Display
 
         //If no folder is open, override the perforce directory to the files
         var directoryOverride = null;
-        if (workspace.rootPath == undefined) {
+        if (workspace.rootPath === undefined) {
             directoryOverride = Path.dirname(doc.uri.fsPath);
         }
 
@@ -69,7 +69,6 @@ export namespace Display
 
     export function showError(error: string) {
         window.setStatusBarMessage("Perforce: " + error, 3000);
-        channel.appendLine("ERROR:");
-        channel.append(error);
+        channel.appendLine(`ERROR: ${JSON.stringify(error)}`);
     }
 }

--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -59,7 +59,7 @@ export default class FileSystemListener
 
         const p4IgnoreFileName = process.env.P4IGNORE ? process.env.P4IGNORE : '.p4ignore';
         workspace.findFiles(p4IgnoreFileName, null, 1).then((result) => {
-            if (result.length > 0) {
+            if (result && result.length > 0) {
                 this._p4ignore = parseignore(result[0].fsPath);
             }
         });

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -298,7 +298,7 @@ export namespace PerforceCommands
         }
 
         showOutput();
-        PerforceService.execute('info', PerforceService.handleCommonServiceResponse);
+        PerforceService.execute('info', PerforceService.handleInfoServiceResponse);
     }
 
     export function opened() {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -428,6 +428,7 @@ export namespace PerforceCommands
         items.push({ label: "add", description: "Open a new file to add it to the depot" });
         items.push({ label: "edit", description: "Open an existing file for edit" });
         items.push({ label: "revert", description: "Discard changes from an opened file" });
+        items.push({ label: "submitDefault", description: "Submit or Save the default changelist" });
         items.push({ label: "diff", description: "Display diff of client file with depot file" });
         items.push({ label: "diffRevision", description: "Display diff of client file with depot file at a specific revision" });
         items.push({ label: "annotate", description: "Print file lines and their revisions" });
@@ -447,6 +448,9 @@ export namespace PerforceCommands
                     break;
                 case "revert":
                     revert();
+                    break;
+                case "submitDefault":
+                    PerforceSCMProvider.SubmitDefault();
                     break;
                 case "diff":
                     diff();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -48,7 +48,7 @@ export namespace PerforceCommands
             PerforceSCMProvider.Open(e);
         });
         commands.registerCommand('perforce.submitDefault', () => {
-            PerforceSCMProvider.Submit();
+            PerforceSCMProvider.SubmitDefault();
         });
         commands.registerCommand('perforce.processChangelist', () => {
             PerforceSCMProvider.ProcessChangelist();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -7,7 +7,7 @@ import {
     Uri
 } from 'vscode';
 
-import { DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
+import { ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
 
 
 import * as Path from 'path';
@@ -124,7 +124,7 @@ export namespace PerforceCommands
                 if(!err) {
                     Display.showError("file opened for edit");
                 }
-                resolve(err);
+                reject(err);
             }, args, directoryOverride);
         });
     }
@@ -265,15 +265,16 @@ export namespace PerforceCommands
                     colorIndex = (colorIndex + 1) % decorateColors.length
                 }
 
+                const before: ThemableDecorationAttachmentRenderOptions = {
+                    contentText: (cl ? '' : '#') + num,
+                    color: decorateColors[colorIndex]
+                };
+                const renderOptions: DecorationInstanceRenderOptions = { before };
+
                 decorations.push({
                     range: new Range(i, 0, i, 0),
                     hoverMessage,
-                    renderOptions: {
-                        before: {
-                            color: decorateColors[colorIndex],
-                            contentText: (cl ? '' : '#') + num
-                        } as DecorationInstanceRenderOptions
-                    }
+                    renderOptions
                 });
 
             }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -1,15 +1,10 @@
 'use strict';
 
 import {
-    commands,
-    workspace,
-    window,
-    Uri
-} from 'vscode';
-
-import { ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions, OverviewRulerLane, Disposable, ExtensionContext, Range, TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
-
-
+    commands, workspace, window, Uri,
+    ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions,
+    OverviewRulerLane, Disposable, ExtensionContext, Range,
+    TextDocument, TextEditor, TextEditorSelectionChangeEvent } from 'vscode';
 import * as Path from 'path';
 import * as fs from 'fs';
 
@@ -490,7 +485,7 @@ export namespace PerforceCommands
 
     export function checkFolderOpened() {
         if (workspace.rootPath == undefined) {
-            Display.showMessage("No folder selected");
+            Display.showMessage("No folder selected\n");
             return false;
         }
 

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -152,6 +152,14 @@ export namespace PerforceService {
 
     }
 
+    export function handleInfoServiceResponse(err: Error, stdout: string, stderr: string) {
+        if (err) {
+            Display.showError(stderr.toString());
+        } else {
+            Display.channel.append(stdout.toString());
+        }
+    }
+    
     export function handleCommonServiceResponse(err: Error, stdout: string, stderr: string) {
         if (err) {
             Display.showError(stderr.toString());

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -124,6 +124,12 @@ export class PerforceSCMProvider {
         await perforceProvider._model.Describe(input);
     };
 
+    public static async SubmitDefault(): Promise<void> {
+        const perforceProvider: PerforceSCMProvider = PerforceSCMProvider.GetInstance();
+
+        await perforceProvider._model.SubmitDefault();
+    };
+    
     public static async Submit(input?: Resource | SourceControlResourceGroup): Promise<void> {
         const perforceProvider: PerforceSCMProvider = PerforceSCMProvider.GetInstance();
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -56,17 +56,17 @@ export class PerforceSCMProvider {
 
     public Initialize() {
         this._model = new Model(this.compatibilityMode);
-        // Hook up the model change event to trigger our own event
-        this._model.onDidChange(this.onDidModelChange, this, this.disposables);
-        this._model.Refresh();
 
         PerforceSCMProvider.instance = this;
         this._model._sourceControl = scm.createSourceControl(this.id, this.label);
         this._model._sourceControl.quickDiffProvider = this;
         this._model._sourceControl.acceptInputCommand = { command: 'perforce.processChangelist', title: 'Process Changelist'};
 
-        scm.inputBox.value = '';
+        // Hook up the model change event to trigger our own event
+        this._model.onDidChange(this.onDidModelChange, this, this.disposables);
+        this._model.Refresh();
 
+        scm.inputBox.value = '';
     }
 
     private onDidModelChange(): void {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -71,7 +71,7 @@ export namespace Utils
                 } else if (stderr) {
                     reject(stderr);
                 } else {
-                    resolve(stdout);
+                    resolve(true);
                 }
             }, '-s');
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,132 @@
 'use strict';
 
-import { ExtensionContext, workspace, commands } from 'vscode';
-
 import { PerforceCommands } from './PerforceCommands';
 import { PerforceContentProvider } from './ContentProvider';
 import FileSystemListener from './FileSystemListener';
 import { PerforceSCMProvider } from './ScmProvider';
+import { IPerforceConfig, PerforceService } from './PerforceService';
 import { Display } from './Display';
+import { Utils } from './Utils';
+import * as vscode from 'vscode';
+import * as Path from 'path';
 
-export function activate(ctx: ExtensionContext) : void {
-    const compatibilityMode = workspace.getConfiguration('perforce').get('compatibilityMode', 'perforce');
-    commands.executeCommand('setContext', 'perforce.compatibilityMode', compatibilityMode);
+// for ini files
+import * as fs from 'fs';
+import * as Ini from 'ini';
 
-    //Register all commands
-    PerforceCommands.registerCommands();
-    Display.initialize();
-    ctx.subscriptions.push(new PerforceContentProvider(compatibilityMode));
-    ctx.subscriptions.push(new FileSystemListener());
-    ctx.subscriptions.push(new PerforceSCMProvider(compatibilityMode));
+let _isRegistered: boolean = false;
+
+function TryCreateP4(path: string, ctx: vscode.ExtensionContext): void {
+    if (!path) return;
+
+    const CreateP4 = (config: IPerforceConfig): void => {
+        const compatibilityMode = vscode.workspace.getConfiguration('perforce').get('compatibilityMode', 'perforce');
+        vscode.commands.executeCommand('setContext', 'perforce.compatibilityMode', compatibilityMode);
+
+        // Register all commands
+        if (!_isRegistered) {
+            _isRegistered = true;
+
+            // todo: register multiple perforce scm for multiple valid roots
+            // by passing/storing/using 'config'
+            // for now, use a single config
+
+            // path fixups:
+            const trailingSlash = /^(.*)(\/)$/;
+
+            if (config.localDir) {
+                config.localDir = Utils.normalize(config.localDir);
+                if (!trailingSlash.exec(config.localDir)) config.localDir += '/';
+            }
+
+            if (config.p4Dir) {
+                config.p4Dir = Utils.normalize(config.p4Dir);
+                if (!trailingSlash.exec(config.p4Dir)) config.p4Dir += '/';
+            }
+
+            PerforceService.setConfig(config);
+            ctx.subscriptions.push(new PerforceContentProvider(compatibilityMode));
+            ctx.subscriptions.push(new FileSystemListener());
+            ctx.subscriptions.push(new PerforceSCMProvider(compatibilityMode));
+
+            // todo: fix dependency / order of operations issues
+            PerforceCommands.registerCommands();
+            Display.initialize();
+        }
+    }
+
+    const CreateP4FromConfig = (configFile: vscode.Uri): void => {
+        const configPath = Path.dirname(configFile.fsPath);
+        // todo: read config
+        const contents = fs.readFileSync(configFile.fsPath, 'utf-8');
+        const cfg = Ini.parse(contents);
+
+        const config: IPerforceConfig = {
+            localDir: configPath,
+            p4Dir: cfg.P4DIR ? Utils.normalize(cfg.P4DIR) : configPath,
+
+            p4Client: cfg.P4CLIENT,
+            p4Host: cfg.P4HOST,
+            p4Pass: cfg.P4PASS,
+            p4Port: cfg.P4PORT,
+            p4Tickets: cfg.P4TICKETS,
+            p4User: cfg.P4USER,
+        };
+
+        CreateP4(config);
+    }
+
+    PerforceService.getClientRoot()
+        .then((cliRoot) => {
+            cliRoot = Utils.normalize(cliRoot);
+
+            const wksRoot = vscode.workspace.rootPath;
+            if (!wksRoot) return CreateP4({ localDir: '' }); // see uses of directoryOverride per file
+
+            // asRelativePath doesn't catch if cliRoot IS wksRoot, so using startsWith
+            // const rel = Utils.normalize(workspace.asRelativePath(cliRoot));
+
+            // todo: per workspace folder for new interface
+            const wksRootN = Utils.normalize(wksRoot);
+            if (wksRootN.startsWith(cliRoot)) return CreateP4({ localDir: wksRootN });
+
+            // is p4dir specified in general settings?
+            const p4Dir = vscode.workspace.getConfiguration('perforce').get('dir', 'none');
+            if (p4Dir !== 'none') {
+                return CreateP4({ localDir: wksRootN });
+            }
+
+            throw 'workspace is not within p4 clientRoot';
+        })
+        .catch((err) => {
+            // workspace is not within client root.
+            // look for .p4config files to specify p4Dir association
+            vscode.workspace.findFiles('**/.p4config', '**/node_modules/**')
+                .then((files: vscode.Uri[]) => {
+
+                    if (!files || files.length === 0) return;
+
+                    files.forEach((file) => {
+                        CreateP4FromConfig(file);
+                    });
+                });
+        });
+}
+
+export function activate(ctx: vscode.ExtensionContext): void {
+
+    // todo: enableProposedApi; workspace.workspaceFolders[]
+
+    //workspace.onDidOpenTextDocument
+
+    // const editor = vscode.window.activeTextEditor;
+    // var filePath = Path.dirname(editor.document.uri.fsPath);
+
+    if (vscode.workspace.rootPath !== undefined) {
+        TryCreateP4(vscode.workspace.rootPath, ctx);
+    } else {
+        vscode.workspace.textDocuments.forEach((uri) => {
+            TryCreateP4(uri.fileName, ctx);
+        });
+    }
 }

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -1,3 +1,4 @@
+import { PerforceService, IPerforceConfig } from './../PerforceService';
 import { scm, Uri, EventEmitter, Event, SourceControl, SourceControlResourceGroup, Disposable, ProgressLocation, window, workspace, commands } from 'vscode';
 import { Utils } from '../Utils';
 import { Display } from '../Display';
@@ -416,7 +417,10 @@ export class Model implements Disposable {
     }
 
     private async syncUpdate(): Promise<void> {
-        await Utils.getOutput('sync').then(output => {
+        const config: IPerforceConfig = PerforceService.getConfig();
+        const pathToSync = config.p4Dir ? config.p4Dir + '...' : null;
+        
+        await Utils.getOutput('sync', pathToSync, null, '-q').then(output => {
             Display.channel.append(output);
             this.Refresh();
         }).catch(reason => {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -183,7 +183,7 @@ export class Model implements Disposable {
         const descStr = await vscode.window.showInputBox({
             placeHolder: 'New changelist description',
             validateInput: (value: string) => {
-                if (!value || value.length === 0) {
+                if (!value || value.trim().length === 0) {
                     return 'Cannot set empty description';
                 }
                 return null;
@@ -191,7 +191,9 @@ export class Model implements Disposable {
             ignoreFocusOut: true
         });
 
-        if (descStr === undefined) {
+        if (descStr === undefined || descStr.trim().length == 0) {
+            // pressing enter with no other input will still submit the empty string
+            Display.showError('Cannot set empty description');
             return;
         }
 


### PR DESCRIPTION
addresses issues #83 and #84 

activation now checks for valid clientRoot and matching local setup before creating the scm provider
todo: support multiple repos for insiders edition; file watchers to detect subsequent activation tests?

for #83: if client root exists but doesn't match, looks for a .p4config file with p4dir=path to use for -d
todo: support .p4config in standard use and to use p4client etc overrides prior to testing for valid p4dir.
todo: harden support (invalid p4Dir, clientRoot relative paths, etc)

includes assorted fixes while testing various features

sadly lots of ancillary edits due to alt-shift F auto-formatting cleanup, and this is based on previous pull requests #87 and etc.