### PR TITLE
Bugfix p4 detection

### DIFF
--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -144,7 +144,8 @@ export namespace PerforceService {
         }
 
         Display.channel.appendLine(cmdLine);
-        var child = CP.exec(cmdLine, { cwd: _config ? _config.localDir : undefined, maxBuffer: maxBuffer }, responseCallback);
+        const cmdArgs = { cwd: _config ? _config.localDir : workspace.rootPath, maxBuffer: maxBuffer };
+        var child = CP.exec(cmdLine, cmdArgs, responseCallback);
 
         if (input != null) {
             child.stdin.end(input, 'utf8');

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -27,6 +27,9 @@ export interface IPerforceConfig {
 
     // root directory of the user space (or .p4config)
     localDir: string;
+
+    // whether to strip the localDir when calling espansePath
+    stripLocalDir?: boolean;
 }
 
 export namespace PerforceService {
@@ -44,6 +47,7 @@ export namespace PerforceService {
     }
     export function convertToRel(path: string): string {
         if (!_config
+            || !_config.stripLocalDir
             || !_config.localDir || _config.localDir.length === 0
             || !_config.p4Dir || _config.p4Dir.length === 0) {
 
@@ -136,7 +140,7 @@ export namespace PerforceService {
         cmdLine += ' ' + command;
 
         if (args != null) {
-            if (_config) {
+            if (_config && _config.stripLocalDir) {
                 args = args.replace(_config.localDir, '');
             }
 
@@ -150,7 +154,6 @@ export namespace PerforceService {
         if (input != null) {
             child.stdin.end(input, 'utf8');
         }
-
     }
 
     export function handleInfoServiceResponse(err: Error, stdout: string, stderr: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ function TryCreateP4(path: string, ctx: vscode.ExtensionContext): void {
 
         const config: IPerforceConfig = {
             localDir: configPath,
+            stripLocalDir: cfg.P4DIR ? true : false,
             p4Dir: cfg.P4DIR ? Utils.normalize(cfg.P4DIR) : configPath,
 
             p4Client: cfg.P4CLIENT,
@@ -103,7 +104,7 @@ function TryCreateP4(path: string, ctx: vscode.ExtensionContext): void {
             const CheckAlways = () => {
                 // if autodetect fails, enable if settings dictate
                 if (vscode.workspace.getConfiguration('perforce').get('activationMode') === 'always') {
-                    const config: IPerforceConfig = { localDir: '' };
+                    const config: IPerforceConfig = { localDir: vscode.workspace.rootPath };
                     CreateP4(config);
                 }
             }


### PR DESCRIPTION
use workspace root as cwd of p4 before configuration files are found
allows proper searching for P4CONFIG files by p4.exe

note that 'always' enable for plugin will not be 'usable' if the autodetect doesn't find the configuration properly.  It does allow better debugging, though - ie: use Alt-P I to display client/server information.