### PR TITLE
Hide non workspace files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Perforce integration for Visual Studio Code
 |`perforce.changelistOrder`         |`string`   |Specifies the direction of the chnagelist sorting (`descending`,`ascending`)
 |`perforce.scmFileChanges`          |`boolean`  |Open file changes when selected in SCM Explorer
 |`perforce.ignoredChangelistPrefix` |`string`   |Specifies the prefix of the changelists to be ignored.
-|`perforce.hideNonWorkspaceFiles`   |`boolean`  |Hide non workspace files in the SCM Explorer.
+|`perforce.hideNonWorkspaceFiles`   |`boolean`  |Hide non workspace files in the SCM Explorer. Default changelist only submits files that are opened in current workspace. Warning: If you submit other changelists than the default it will submit files that are not visible.
 
 
 ## Activation

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Perforce integration for Visual Studio Code
 |`perforce.changelistOrder`         |`string`   |Specifies the direction of the chnagelist sorting (`descending`,`ascending`)
 |`perforce.scmFileChanges`          |`boolean`  |Open file changes when selected in SCM Explorer
 |`perforce.ignoredChangelistPrefix` |`string`   |Specifies the prefix of the changelists to be ignored.
+|`perforce.hideNonWorkspaceFiles`   |`boolean`  |Hide non workspace files in the SCM Explorer.
 
 
 ## Activation

--- a/package.json
+++ b/package.json
@@ -183,6 +183,11 @@
                 "perforce.ignoredChangelistPrefix": {
                     "type": "string",
                     "description": "Specifies the prefix of the changelists to be ignored."
+                },
+                "perforce.hideNonWorkspaceFiles": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Don't show files that are not in the current opened workspace."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
                 "perforce.hideNonWorkspaceFiles": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Don't show files that are not in the current opened workspace."
+                    "description": "Don't show files that are not in the current opened workspace. Default changelist only submits files that are opened in current workspace.  Warning: If you submit other changelists than the default it will submit files that are not visible."
                 }
             }
         },

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -506,6 +506,8 @@ export class Model implements Disposable {
             }
         }
 
+        const hideNonWorksSpaceFiles = config.get<boolean>('hideNonWorkspaceFiles');
+
         const depotOpenedFilePaths = await this.getDepotOpenedFilePaths();
         for (let i = 0; i < depotOpenedFilePaths.length; i += maxFilePerCommand) {
             const fstatInfo = await this.getFstatInfoForFiles(depotOpenedFilePaths.slice(i, i + maxFilePerCommand));
@@ -516,6 +518,12 @@ export class Model implements Disposable {
                 const action = info['action'];
                 const headType = info['headType'];
                 const uri = Uri.file(clientFile);
+                if (hideNonWorksSpaceFiles) {
+                    const workspaceFolder = workspace.getWorkspaceFolder(uri);
+                    if (!workspaceFolder) {
+                        return
+                    }
+                }
                 const resource: Resource = new Resource(this, uri, change, action, headType);
 
                 if (change.startsWith('default')) {


### PR DESCRIPTION
Hide non workspace files to reduce clutter when you have lots of files opened in different projects.