### PR TITLE
Cleanup bottleneck setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 *.vsix
+package-lock.json

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -146,7 +146,7 @@ export namespace PerforceService {
     }
 
     export function execute(resource: Uri, command: string, responseCallback: (err: Error, stdout: string, stderr: string) => void, args?: string, directoryOverride?: string, input?: string): void {
-        limiter.submit({ id: `<JOB_ID:${Date.now()}:${command}>`}, execCommand, resource, command, responseCallback, args, directoryOverride, input, null);
+        limiter.submit({ id: `<JOB_ID:${Date.now()}:${command}>` }, execCommand, resource, command, responseCallback, args, directoryOverride, input, null);
     }
 
     export function executeAsPromise(resource: Uri, command: string, args?: string, directoryOverride?: string, input?: string): Promise<string> {

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -146,12 +146,6 @@ export namespace PerforceService {
     }
 
     export function execute(resource: Uri, command: string, responseCallback: (err: Error, stdout: string, stderr: string) => void, args?: string, directoryOverride?: string, input?: string): void {
-        if (debugModeActive && !debugModeSetup) {
-            limiter.on('debug', (message, data) => {
-                console.log('Bottleneck Debug:', message, data);
-            });
-            debugModeSetup = true;
-        }
         limiter.submit({ id: `<JOB_ID:${Date.now()}:${command}>`}, execCommand, resource, command, responseCallback, args, directoryOverride, input, null);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ function TryCreateP4(uri: vscode.Uri):  Promise<boolean> {
             }
 
             PerforceService.addConfig(config, wksUri.fsPath);
+            PerforceService.setupThrottling(vscode.workspace.getConfiguration('perforce').get('debugModeActive'));
             _disposable.push(new PerforceSCMProvider(config, wksUri, compatibilityMode));
             _disposable.push(new FileSystemListener(wksFolder));
 


### PR DESCRIPTION
The bottleneck debug setup was a bit janky. This also adds a specific debug line for dropped commands so that users can see if this functionality is being hit or not. I still think there is likely work to be done with the dropped commands. I think they'd still be executing in the child process even when dropped. I'm thinking we'll have to keep track of all child processes in the `PerforceService` and then call end on any processes that come through the `onCommandDropped` callback similar to how you're ending them in `execCommand` currently:

```
var child = CP.exec(cmdLine, cmdArgs, responseCallback);

if (input != null) {
    child.stdin.end(input, 'utf8');
}
```