### PR TITLE
Add Swarm link to annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Perforce integration for Visual Studio Code
 |`perforce.scmFileChanges`          |`boolean`  |Open file changes when selected in SCM Explorer
 |`perforce.ignoredChangelistPrefix` |`string`   |Specifies the prefix of the changelists to be ignored.
 |`perforce.hideNonWorkspaceFiles`   |`boolean`  |Hide non workspace files in the SCM Explorer. Default changelist only submits files that are opened in current workspace. Warning: If you submit other changelists than the default it will submit files that are not visible.
+|`perforce.swarmHost`               |`string`   |Specifies the hostname of the Swarm server for annotation links. (`https://localhost`)
 |`perforce.hideShelvedFiles`        |`boolean`  |Hide shelved files in the SCM Explorer.
 |`perforce.hideEmptyChangelists`    |`boolean`  |Hide changelists with no file in the SCM Explorer.
 |&nbsp;

--- a/package.json
+++ b/package.json
@@ -241,6 +241,10 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Don't show changelists without any file in the Source Control section."
+                },
+                "perforce.swarmHost": {
+                    "type": "string",
+                    "description": "Specifies the host of the Swarm server for annotation links"
                 }
             }
         },

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -4,7 +4,7 @@ import {
     commands, workspace, window, Uri,
     ThemableDecorationAttachmentRenderOptions, DecorationInstanceRenderOptions, DecorationOptions,
     OverviewRulerLane, Disposable, ExtensionContext, Range, QuickPickItem,
-    TextDocument, TextEditor, TextEditorSelectionChangeEvent, WorkspaceFolder } from 'vscode';
+    TextDocument, TextEditor, TextEditorSelectionChangeEvent, WorkspaceFolder, MarkdownString } from 'vscode';
 
 import * as Path from 'path';
 import * as fs from 'fs';
@@ -236,6 +236,7 @@ export namespace PerforceCommands
         const conf = workspace.getConfiguration('perforce')
         const cl = conf.get('annotate.changelist');
         const usr = conf.get('annotate.user');
+        const swarmHost = conf.get('swarmHost');
         let args = '-q';
         if (cl) args += 'c';
         if (usr) args += 'u';
@@ -258,7 +259,7 @@ export namespace PerforceCommands
             const matches = annotations[i].match(usr ? /^(\d+): (\S+ \S+)/ : /^(\d+): /);
             if(matches) {
                 const num = matches[1];
-                const hoverMessage = matches[2];
+                const hoverMessage = swarmHost ? new MarkdownString(`[${num + ' ' + matches[2]}](${swarmHost}/changes/${num})`) : matches[2];
 
                 if (num !== lastNum) {
                     lastNum = num;


### PR DESCRIPTION
* Adds a config option `swarmHost` to specify as the hostname to link to
* If configured, allows clicking on a annotation hover to go to that change in Swarm.