### PR TITLE
Shelving & diffing enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 *.vsix
+.vscode-test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,28 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src",
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
             "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+                "${workspaceFolder}/test-fixtures/core"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 typings/**
 out/test/**
 test/**
+test-fixtures/**
 src/**
 **/*.map
 .gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,107 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@sinonjs/commons": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+            "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/formatio": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+            "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^4.2.0"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
+            "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.6.0",
+                "array-from": "^2.1.1",
+                "lodash.get": "^4.4.2"
+            }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "@types/chai": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+            "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+            "dev": true
+        },
+        "@types/chai-as-promised": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+            "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
+            "dev": true,
+            "requires": {
+                "@types/chai": "*"
+            }
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+            "dev": true
+        },
+        "@types/glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+            "dev": true,
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+            "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+            "dev": true
+        },
         "@types/node": {
             "version": "8.10.59",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
             "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
             "dev": true
+        },
+        "@types/sinon": {
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
+            "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+            "dev": true
+        },
+        "@types/sinon-chai": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
+            "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+            "dev": true,
+            "requires": {
+                "@types/chai": "*",
+                "@types/sinon": "*"
+            }
         },
         "@types/tmp": {
             "version": "0.0.33",
@@ -37,6 +133,36 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -51,6 +177,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+            "dev": true
         },
         "array-unique": {
             "version": "0.3.2",
@@ -70,6 +202,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
         "assign-symbols": {
@@ -235,10 +373,67 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
+        "chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "requires": {
+                "check-error": "^1.0.2"
+            }
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
         },
         "class-utils": {
@@ -262,6 +457,45 @@
                 }
             }
         },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -270,6 +504,21 @@
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
             }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -325,10 +574,34 @@
                 "ms": "2.0.0"
             }
         },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
         },
         "define-property": {
             "version": "2.0.2",
@@ -389,6 +662,42 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
+        "es-abstract": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+            "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -408,6 +717,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
         "expand-brackets": {
@@ -565,6 +880,32 @@
                 }
             }
         },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "flat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+            "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "~2.0.3"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+                    "dev": true
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -599,6 +940,24 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
         "get-value": {
@@ -651,10 +1010,25 @@
                 "har-schema": "^2.0.0"
             }
         },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
             "dev": true
         },
         "has-value": {
@@ -687,9 +1061,9 @@
             }
         },
         "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
         "http-proxy-agent": {
@@ -795,6 +1169,12 @@
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
+        "is-callable": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+            "dev": true
+        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -812,6 +1192,12 @@
                     }
                 }
             }
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -839,6 +1225,12 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
         },
         "is-glob": {
             "version": "3.1.0",
@@ -874,6 +1266,24 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-regex": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -890,6 +1300,12 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -900,6 +1316,16 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -937,10 +1363,56 @@
                 "verror": "1.10.0"
             }
         },
+        "just-extend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+            "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            }
+        },
+        "lolex": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
         },
         "map-cache": {
             "version": "0.2.2",
@@ -1034,37 +1506,49 @@
             }
         },
         "mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+            "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
             "dev": true,
             "requires": {
+                "ansi-colors": "3.2.3",
                 "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
+                "debug": "3.2.6",
                 "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
+                "find-up": "3.0.0",
+                "glob": "7.1.3",
                 "growl": "1.10.5",
-                "he": "1.1.1",
+                "he": "1.2.0",
+                "js-yaml": "3.13.1",
+                "log-symbols": "2.2.0",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.5",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "13.3.0",
+                "yargs-parser": "13.1.1",
+                "yargs-unparser": "1.6.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1074,6 +1558,12 @@
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
@@ -1098,6 +1588,30 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
+            }
+        },
+        "nise": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
+            "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/formatio": "^4.0.1",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^5.0.1",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
+        "node-environment-flags": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+            "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+            "dev": true,
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3",
+                "semver": "^5.7.0"
             }
         },
         "oauth-sign": {
@@ -1134,12 +1648,46 @@
                 }
             }
         },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "requires": {
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+            "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "object.pick": {
@@ -1164,6 +1712,30 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
+        "p-limit": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
         "parse-gitignore": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.4.0.tgz",
@@ -1178,10 +1750,39 @@
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
             "dev": true
         },
         "performance-now": {
@@ -1266,6 +1867,18 @@
                 "uuid": "^3.3.2"
             }
         },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1281,6 +1894,15 @@
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
         },
         "safe-buffer": {
             "version": "5.2.0",
@@ -1308,6 +1930,12 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true
         },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
         "set-value": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -1328,6 +1956,50 @@
                     }
                 }
             }
+        },
+        "sinon": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.1.tgz",
+            "integrity": "sha512-vbXMHBszVioyPsuRDLEiPEgvkZnbjfdCFvLYV4jONNJqZNLWTwZ/gYSNh3SuiT1w9MRXUz+S7aX0B4Ar2XI8iw==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/formatio": "^4.0.1",
+                "@sinonjs/samsam": "^4.0.1",
+                "diff": "^4.0.1",
+                "lolex": "^5.1.2",
+                "nise": "^3.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+                    "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "sinon-chai": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.4.0.tgz",
+            "integrity": "sha512-BpVxsjEkGi6XPbDXrgWUe7Cb1ZzIfxKUbu/MmH5RoUnS7AXpKo3aIYIyQUg0FMvlUL05aPt7VZuAdaeQhEnWxg==",
+            "dev": true
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -1474,6 +2146,12 @@
                 "extend-shallow": "^3.0.0"
             }
         },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -1510,10 +2188,55 @@
                 }
             }
         },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
         "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+            "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
@@ -1596,6 +2319,12 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
         "typescript": {
@@ -1710,16 +2439,151 @@
                 "source-map-support": "^0.5.0",
                 "url-parse": "^1.4.4",
                 "vscode-test": "^0.4.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "he": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+                    "dev": true
+                },
+                "mocha": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+                    "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+                    "dev": true,
+                    "requires": {
+                        "browser-stdout": "1.3.1",
+                        "commander": "2.15.1",
+                        "debug": "3.1.0",
+                        "diff": "3.5.0",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.5",
+                        "he": "1.1.1",
+                        "minimatch": "3.0.4",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "5.4.0"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.2",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "vscode-test": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+                    "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+                    "dev": true,
+                    "requires": {
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1"
+                    }
+                }
             }
         },
         "vscode-test": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",
+            "integrity": "sha512-LddukcBiSU2FVTDr3c1D8lwkiOvwlJdDL2hqVbn6gIz+rpTqUCkMZSKYm94Y1v0WXlHSDQBsXyY+tchWQgGVsw==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1"
+                "https-proxy-agent": "^2.2.4",
+                "rimraf": "^2.6.3"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "wrappy": {
@@ -1727,6 +2591,79 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+            "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+            "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yargs-unparser": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+            "dev": true,
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,14 @@
             }
         },
         "@sinonjs/samsam": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
-            "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+            "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.6.0",
-                "array-from": "^2.1.1",
-                "lodash.get": "^4.4.2"
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
             }
         },
         "@sinonjs/text-encoding": {
@@ -177,12 +177,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-        },
-        "array-from": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-            "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-            "dev": true
         },
         "array-unique": {
             "version": "0.3.2",
@@ -1591,9 +1585,9 @@
             }
         },
         "nise": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
-            "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+            "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0",
@@ -1958,24 +1952,24 @@
             }
         },
         "sinon": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.1.tgz",
-            "integrity": "sha512-vbXMHBszVioyPsuRDLEiPEgvkZnbjfdCFvLYV4jONNJqZNLWTwZ/gYSNh3SuiT1w9MRXUz+S7aX0B4Ar2XI8iw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.0.tgz",
+            "integrity": "sha512-6/05TR+8QhEgTbyMWaConm8iPL609Eno7SqToPq63wC/jS/6NMEI4NxqtzlLkk3r/KcZT9xPXQodH0oJ917Hbg==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0",
                 "@sinonjs/formatio": "^4.0.1",
-                "@sinonjs/samsam": "^4.0.1",
-                "diff": "^4.0.1",
+                "@sinonjs/samsam": "^4.2.2",
+                "diff": "^4.0.2",
                 "lolex": "^5.1.2",
-                "nise": "^3.0.0",
+                "nise": "^3.0.1",
                 "supports-color": "^7.1.0"
             },
             "dependencies": {
                 "diff": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-                    "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
                     "dev": true
                 },
                 "has-flag": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1732 @@
+{
+    "name": "perforce",
+    "version": "3.2.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "8.10.59",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
+            "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+            "dev": true
+        },
+        "@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
+        "ajv": {
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+            "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "requires": {
+                "is-extglob": "^2.1.0"
+            }
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "kind-of": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            }
+        },
+        "mime-db": {
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+            "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.25",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+            "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.42.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "parse-gitignore": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.4.0.tgz",
+            "integrity": "sha1-q/cC5LkAUk//eQK2g4YoV7Y/k/4=",
+            "requires": {
+                "array-unique": "^0.3.2",
+                "is-glob": "^3.1.0"
+            }
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "psl": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+            "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "dev": true
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "safe-buffer": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+            "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+            "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+            "dev": true
+        },
+        "union-value": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
+            }
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "uuid": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "vscode": {
+            "version": "1.1.36",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.36.tgz",
+            "integrity": "sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.2",
+                "mocha": "^5.2.0",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.4",
+                "vscode-test": "^0.4.1"
+            }
+        },
+        "vscode-test": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "sourcedepot",
         "multi-root ready"
     ],
-    "main": "./out/src/extension",
+    "main": "./out/extension",
     "activationEvents": [
         "*"
     ],
@@ -686,15 +686,30 @@
         "tmp": "^0.0.33"
     },
     "devDependencies": {
+        "@types/chai": "^4.2.7",
+        "@types/chai-as-promised": "^7.1.2",
+        "@types/glob": "^7.1.1",
+        "@types/mocha": "^5.2.7",
         "@types/node": "^8.0.8",
+        "@types/sinon": "^7.5.1",
+        "@types/sinon-chai": "^3.2.3",
         "@types/tmp": "^0.0.33",
+        "chai": "^4.2.0",
+        "chai-as-promised": "^7.1.1",
+        "glob": "^7.1.6",
+        "mocha": "^6.2.2",
+        "sinon": "^8.0.1",
+        "sinon-chai": "^3.4.0",
         "typescript": "^3.7.3",
-        "vscode": "^1.1.36"
+        "vscode": "^1.1.36",
+        "vscode-test": "^1.3.0"
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
+        "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "pretest": "npm run compile",
+        "test": "node ./out/test/runTest.js"
     }
 }

--- a/package.json
+++ b/package.json
@@ -355,6 +355,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.openResourcevShelved",
+                "title": "Open workspace vs shelved changes",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.openFile",
                 "title": "Open file",
                 "category": "Perforce"
@@ -590,6 +595,11 @@
                     "group": "navigation"
                 },
                 {
+                    "command": "perforce.openResourcevShelved",
+                    "when": "scmProvider == perforce",
+                    "group": "navigation"
+                },
+                {
                     "command": "perforce.openFile",
                     "when": "scmProvider == perforce",
                     "group": "navigation"
@@ -678,8 +688,8 @@
     "devDependencies": {
         "@types/node": "^8.0.8",
         "@types/tmp": "^0.0.33",
-        "typescript": "^2.0.3",
-        "vscode": "^1.1.33"
+        "typescript": "^3.7.3",
+        "vscode": "^1.1.36"
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -540,22 +540,22 @@
                 {
                     "command": "perforce.shelveChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "1_modification@5"
+                    "group": "2_shelving@1"
                 },
                 {
                     "command": "perforce.shelveRevertChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "1_modification@6"
+                    "group": "2_shelving@2"
                 },
                 {
                     "command": "perforce.unshelveChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "1_modification@7"
+                    "group": "2_shelving@3"
                 },
                 {
                     "command": "perforce.describe",
                     "when": "scmProvider == perforce",
-                    "group": "2_info"
+                    "group": "3_info"
                 }
             ],
             "scm/resourceState/context": [

--- a/package.json
+++ b/package.json
@@ -410,6 +410,16 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.shelveRevertChangelist",
+                "title": "Shelve and revert changelist",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.unshelveChangelist",
+                "title": "Unshelve changelist",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.describe",
                 "title": "Describe changelist",
                 "category": "Perforce"
@@ -531,6 +541,16 @@
                     "command": "perforce.shelveChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
                     "group": "1_modification@5"
+                },
+                {
+                    "command": "perforce.shelveRevertChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "1_modification@6"
+                },
+                {
+                    "command": "perforce.unshelveChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "1_modification@7"
                 },
                 {
                     "command": "perforce.describe",

--- a/package.json
+++ b/package.json
@@ -698,7 +698,7 @@
         "chai-as-promised": "^7.1.1",
         "glob": "^7.1.6",
         "mocha": "^6.2.2",
-        "sinon": "^8.0.1",
+        "sinon": "^8.1.0",
         "sinon-chai": "^3.4.0",
         "typescript": "^3.7.3",
         "vscode": "^1.1.36",

--- a/package.json
+++ b/package.json
@@ -420,6 +420,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.deleteShelvedChangelist",
+                "title": "Delete shelved files",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.describe",
                 "title": "Describe changelist",
                 "category": "Perforce"
@@ -551,6 +556,11 @@
                     "command": "perforce.unshelveChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
                     "group": "2_shelving@3"
+                },
+                {
+                    "command": "perforce.deleteShelvedChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "2_shelving@4"
                 },
                 {
                     "command": "perforce.describe",

--- a/package.json
+++ b/package.json
@@ -405,6 +405,11 @@
                 }
             },
             {
+                "command": "perforce.shelveChangelist",
+                "title": "Shelve changelist",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.describe",
                 "title": "Describe changelist",
                 "category": "Perforce"
@@ -521,6 +526,11 @@
                     "command": "perforce.revertUnchangedChangelist",
                     "when": "scmProvider == perforce",
                     "group": "1_modification@4"
+                },
+                {
+                    "command": "perforce.shelveChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "1_modification@5"
                 },
                 {
                     "command": "perforce.describe",

--- a/resources/icons/dark/status-shelve-add.svg
+++ b/resources/icons/dark/status-shelve-add.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SA
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-archive.svg
+++ b/resources/icons/dark/status-shelve-archive.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    Sa
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-branch.svg
+++ b/resources/icons/dark/status-shelve-branch.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SB
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-delete.svg
+++ b/resources/icons/dark/status-shelve-delete.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SD
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-edit.svg
+++ b/resources/icons/dark/status-shelve-edit.svg
@@ -1,6 +1,6 @@
 <svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
   <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
-    S
+    SE
   </text>
 </svg>

--- a/resources/icons/dark/status-shelve-integrate.svg
+++ b/resources/icons/dark/status-shelve-integrate.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SI
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-lock.svg
+++ b/resources/icons/dark/status-shelve-lock.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SL
+  </text>
+</svg>

--- a/resources/icons/dark/status-shelve-move.svg
+++ b/resources/icons/dark/status-shelve-move.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SM
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-add.svg
+++ b/resources/icons/light/status-shelve-add.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SA
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-archive.svg
+++ b/resources/icons/light/status-shelve-archive.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    Sa
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-branch.svg
+++ b/resources/icons/light/status-shelve-branch.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SB
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-delete.svg
+++ b/resources/icons/light/status-shelve-delete.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SD
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-edit.svg
+++ b/resources/icons/light/status-shelve-edit.svg
@@ -1,6 +1,6 @@
 <svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
   <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
-    S
+    SE
   </text>
 </svg>

--- a/resources/icons/light/status-shelve-integrate.svg
+++ b/resources/icons/light/status-shelve-integrate.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SI
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-lock.svg
+++ b/resources/icons/light/status-shelve-lock.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SL
+  </text>
+</svg>

--- a/resources/icons/light/status-shelve-move.svg
+++ b/resources/icons/light/status-shelve-move.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#6c4b5e" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    SM
+  </text>
+</svg>

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -73,4 +73,9 @@ export namespace Display
         window.setStatusBarMessage("Perforce: " + error, 3000);
         channel.appendLine(`ERROR: ${JSON.stringify(error)}`);
     }
+
+    export function showImportantError(error: string) {
+        window.showErrorMessage(error);
+        channel.appendLine(`ERROR: ${JSON.stringify(error)}`);
+    }
 }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -281,14 +281,7 @@ export namespace PerforceCommands
             }
         }
 
-        let p4Uri = doc.uri;
-        let query = encodeURIComponent('-q');
-        p4Uri = p4Uri.with({
-            scheme: 'perforce',
-            authority: 'print',
-            path: doc.uri.path,
-            query: query
-        });
+        let p4Uri = Utils.makePerforceDocUri(doc.uri, 'print', '-q');
 
         workspace.openTextDocument(p4Uri).then(d => {
             window.showTextDocument(d).then(e => {

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -1,4 +1,3 @@
-import { IPerforceConfig } from './PerforceService';
 import {
     workspace,
     window,

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -98,6 +98,7 @@ export class PerforceSCMProvider {
         commands.registerCommand('perforce.shelveChangelist', PerforceSCMProvider.ShelveChangelist);
         commands.registerCommand('perforce.shelveRevertChangelist', PerforceSCMProvider.ShelveRevertChangelist);
         commands.registerCommand('perforce.unshelveChangelist', PerforceSCMProvider.UnshelveChangelist);
+        commands.registerCommand('perforce.deleteShelvedChangelist', PerforceSCMProvider.DeleteShelvedChangelist);
         commands.registerCommand('perforce.shelveunshelve', PerforceSCMProvider.ShelveOrUnshelve);
         commands.registerCommand('perforce.revertFile', PerforceSCMProvider.Revert);
         commands.registerCommand('perforce.revertUnchangedFile', PerforceSCMProvider.RevertUnchanged);
@@ -236,6 +237,13 @@ export class PerforceSCMProvider {
         let model: Model = input['model'];
         if (model) {
             await model.UnshelveChangelist(input);
+        }
+    }
+
+    public static async DeleteShelvedChangelist(input: SourceControlResourceGroup) {
+        let model: Model = input['model'];
+        if (model) {
+            await model.DeleteShelvedChangelist(input);
         }
     }
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -96,6 +96,8 @@ export class PerforceSCMProvider {
         commands.registerCommand('perforce.revertChangelist', PerforceSCMProvider.Revert);
         commands.registerCommand('perforce.revertUnchangedChangelist', PerforceSCMProvider.RevertUnchanged);
         commands.registerCommand('perforce.shelveChangelist', PerforceSCMProvider.ShelveChangelist);
+        commands.registerCommand('perforce.shelveRevertChangelist', PerforceSCMProvider.ShelveRevertChangelist);
+        commands.registerCommand('perforce.unshelveChangelist', PerforceSCMProvider.UnshelveChangelist);
         commands.registerCommand('perforce.shelveunshelve', PerforceSCMProvider.ShelveOrUnshelve);
         commands.registerCommand('perforce.revertFile', PerforceSCMProvider.Revert);
         commands.registerCommand('perforce.revertUnchangedFile', PerforceSCMProvider.RevertUnchanged);
@@ -220,6 +222,20 @@ export class PerforceSCMProvider {
         let model: Model = input['model'];
         if (model) {
             await model.ShelveChangelist(input);
+        }
+    }
+
+    public static async ShelveRevertChangelist(input: SourceControlResourceGroup) {
+        let model: Model = input['model'];
+        if (model) {
+            await model.ShelveChangelist(input, true);
+        }
+    }
+
+    public static async UnshelveChangelist(input: SourceControlResourceGroup) {
+        let model: Model = input['model'];
+        if (model) {
+            await model.UnshelveChangelist(input);
         }
     }
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -95,6 +95,7 @@ export class PerforceSCMProvider {
         commands.registerCommand('perforce.submitChangelist', PerforceSCMProvider.Submit);
         commands.registerCommand('perforce.revertChangelist', PerforceSCMProvider.Revert);
         commands.registerCommand('perforce.revertUnchangedChangelist', PerforceSCMProvider.RevertUnchanged);
+        commands.registerCommand('perforce.shelveChangelist', PerforceSCMProvider.ShelveChangelist);
         commands.registerCommand('perforce.shelveunshelve', PerforceSCMProvider.ShelveOrUnshelve);
         commands.registerCommand('perforce.revertFile', PerforceSCMProvider.Revert);
         commands.registerCommand('perforce.revertUnchangedFile', PerforceSCMProvider.RevertUnchanged);
@@ -214,6 +215,13 @@ export class PerforceSCMProvider {
             model.Revert(group, true);
         }
     };
+
+    public static async ShelveChangelist(input: SourceControlResourceGroup) {
+        let model: Model = input['model'];
+        if (model) {
+            await model.ShelveChangelist(input);
+        }
+    }
 
     public static async ShelveOrUnshelve(...resourceStates: SourceControlResourceState[]): Promise<void> {
         const selection = resourceStates.filter(s => s instanceof Resource) as Resource[];

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -35,6 +35,45 @@ export namespace Utils {
         return relativeToRoot;        
     }
 
+    export function getDepotPathFromDepotUri(uri : Uri) : string {
+        return "//"+uri.authority+uri.path;
+    }
+
+    function encodeParam(param : string , value?: any) {
+        if (value !== undefined && typeof value === 'string') {
+            return encodeURIComponent(param) + "=" + encodeURIComponent(value);
+        } else if (value === undefined || value) {
+            return encodeURIComponent(param)
+        }
+    }
+
+    export function makePerforceDocUri(uri : Uri, command: string, p4Args?: string, otherArgs?: {[key: string]: string | boolean}) {
+        return uri.with({scheme: 'perforce', query: makePerforceUriQuery(command, p4Args ?? '', otherArgs)});
+    }
+
+    export function makePerforceUriQuery(command: string, p4Args: string, otherArgs?: {[key: string]: string | boolean}) {
+        let allArgs = [encodeParam('p4args', p4Args), encodeParam('command', command)];
+        if (otherArgs) {
+            allArgs.push(...
+                Object.keys(otherArgs).map((key) => encodeParam(key, otherArgs[key]))
+            )
+        }
+        return allArgs.join("&");
+    }
+
+    export function decodeUriQuery(query: string) {
+        let argArr = query?.split("&") ?? [];
+        const allArgs = {};
+        argArr.forEach(arg => {
+            const parts = arg.split("=");
+            const name = decodeURIComponent(parts[0]);
+            const value = parts[1] ? decodeURIComponent(parts[1]) : true;
+            allArgs[name] = value;
+        });
+
+        return allArgs;
+    }
+
     export function processInfo(output): Map<string, string> {
         const map = new Map<string, string>();
         const lines = output.trim().split('\n');
@@ -89,8 +128,20 @@ export namespace Utils {
         });
     }
 
+    export function getOutputs(resource: Uri, command: string): Promise<[string, string]> {
+        return new Promise((resolve, reject) => {
+            PerforceService.execute(resource, command, (err, stdout, stderr) => {
+                err && Display.showError(err.toString());
+                if (err) {
+                    reject(err);
+                }
+                resolve([stdout, stderr]);
+            });
+        });
+    }
+
     // Get a string containing the output of the command
-    export function runCommand(resource: Uri, command: string, file?: Uri | null, revision?: number, prefixArgs?: string, gOpts?: string, input?: string): Promise<string> {
+    export function runCommand(resource: Uri, command: string, file?: Uri | string | null, revision?: number | string, prefixArgs?: string, gOpts?: string, input?: string): Promise<string> {
         return new Promise((resolve, reject) => {
             let args = prefixArgs != null ? prefixArgs : '';
     
@@ -98,7 +149,12 @@ export namespace Utils {
                 command = gOpts + ' ' + command;
             }
     
-            var revisionString: string = revision == null || isNaN(revision) ? '' : `#${revision}`;
+            let revisionString: string = '';
+            if (typeof revision === 'string') {
+                revisionString = revision;
+            } else if (revision != null && !isNaN(revision)) {
+                revision = `#${revision}`;
+            }
     
             if (file) {
                 let path = (typeof file === 'string') ? file : file.fsPath;
@@ -122,7 +178,7 @@ export namespace Utils {
     }
 
     // Get a string containing the output of the command specific to a file
-    export function runCommandForFile(command: string, file: Uri, revision?: number, prefixArgs?: string, gOpts?: string, input?: string): Promise<string> {
+    export function runCommandForFile(command: string, file: Uri, revision?: number | string, prefixArgs?: string, gOpts?: string, input?: string): Promise<string> {
         let resource = file;
         return runCommand(resource, command, file, revision, prefixArgs, gOpts, input);
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -153,7 +153,7 @@ export namespace Utils {
             if (typeof revision === 'string') {
                 revisionString = revision;
             } else if (revision != null && !isNaN(revision)) {
-                revision = `#${revision}`;
+                revisionString = `#${revision}`;
             }
     
             if (file) {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -55,7 +55,7 @@ export namespace Utils {
         let allArgs = [encodeParam('p4args', p4Args), encodeParam('command', command)];
         if (otherArgs) {
             allArgs.push(...
-                Object.keys(otherArgs).map((key) => encodeParam(key, otherArgs[key]))
+                Object.keys(otherArgs).filter(key => otherArgs[key] !== false).map((key) => encodeParam(key, otherArgs[key]))
             )
         }
         return allArgs.join("&");
@@ -184,6 +184,7 @@ export namespace Utils {
     }
 
     // Get a path to a file containing the output of the command
+    // TODO this is only used for print - seems unecessary when we have a perforce content provider
     export function getFile(command: string, file: Uri, revision?: number, prefixArgs?: string): Promise<string> {
         let resource = file;
         return new Promise((resolve, reject) => {

--- a/src/scm/DecorationProvider.ts
+++ b/src/scm/DecorationProvider.ts
@@ -5,13 +5,13 @@ import * as path from 'path';
 export class DecorationProvider {
     private static _iconsRootPath: string = path.join(path.dirname(__dirname), '..', '..', 'resources', 'icons');
 
-    public static getDecorations(statuses: Status[]): SourceControlResourceDecorations {
+    public static getDecorations(statuses: Status[], isShelved: boolean): SourceControlResourceDecorations {
         const status: Status = this.getDominantStatus(statuses);
-        const light = { iconPath: DecorationProvider.getIconPath(status, 'light') };
-        const dark = { iconPath: DecorationProvider.getIconPath(status, 'dark') };
+        const light = { iconPath: DecorationProvider.getIconPath(status, isShelved, 'light') };
+        const dark = { iconPath: DecorationProvider.getIconPath(status, isShelved, 'dark') };
 
         const strikeThrough = DecorationProvider.useStrikeThrough(status);
-        const faded = DecorationProvider.useFaded(status);
+        const faded = isShelved;
 
         return { strikeThrough, faded, light, dark };
     }
@@ -46,29 +46,25 @@ export class DecorationProvider {
         return Uri.file(path.join(DecorationProvider._iconsRootPath, theme, `${iconName}.svg`));
     }
 
-    private static getIconPath(status: Status, theme: string): Uri | undefined {
+    private static getIconPath(status: Status, isShelved: boolean, theme: string): Uri | undefined {
+        const base = 'status-' + (isShelved ? 'shelve-' : '');
         switch (status) {
-            case Status.ADD: return DecorationProvider.getIconUri('status-add', theme);
-            case Status.ARCHIVE: return DecorationProvider.getIconUri('status-archive', theme);
-            case Status.BRANCH: return DecorationProvider.getIconUri('status-branch', theme);
-            case Status.DELETE: return DecorationProvider.getIconUri('status-delete', theme);
-            case Status.EDIT: return DecorationProvider.getIconUri('status-edit', theme);
-            case Status.IMPORT: return DecorationProvider.getIconUri('status-integrate', theme);
-            case Status.INTEGRATE: return DecorationProvider.getIconUri('status-integrate', theme);
-            case Status.LOCK: return DecorationProvider.getIconUri('status-lock', theme);
-            case Status.MOVE_ADD: return DecorationProvider.getIconUri('status-move', theme);
-            case Status.MOVE_DELETE: return DecorationProvider.getIconUri('status-move', theme);
-            case Status.PURGE: return DecorationProvider.getIconUri('status-delete', theme);
-            case Status.SHELVE: return DecorationProvider.getIconUri('status-shelve', theme);
+            case Status.ADD: return DecorationProvider.getIconUri(base+'add', theme);
+            case Status.ARCHIVE: return DecorationProvider.getIconUri(base+'archive', theme);
+            case Status.BRANCH: return DecorationProvider.getIconUri(base+'branch', theme);
+            case Status.DELETE: return DecorationProvider.getIconUri(base+'delete', theme);
+            case Status.EDIT: return DecorationProvider.getIconUri(base+'edit', theme);
+            case Status.IMPORT: return DecorationProvider.getIconUri(base+'integrate', theme);
+            case Status.INTEGRATE: return DecorationProvider.getIconUri(base+'integrate', theme);
+            case Status.LOCK: return DecorationProvider.getIconUri(base+'lock', theme);
+            case Status.MOVE_ADD: return DecorationProvider.getIconUri(base+'move', theme);
+            case Status.MOVE_DELETE: return DecorationProvider.getIconUri(base+'move', theme);
+            case Status.PURGE: return DecorationProvider.getIconUri(base+'delete', theme);
             default: return void 0;
         }
     }
 
     private static useStrikeThrough(status: Status): boolean {
         return (status === Status.DELETE) || status === Status.MOVE_DELETE;
-    }
-
-    private static useFaded(status: Status): boolean {
-        return (status === Status.SHELVE);
     }
 }

--- a/src/scm/DecorationProvider.ts
+++ b/src/scm/DecorationProvider.ts
@@ -3,7 +3,7 @@ import { Status } from './Status';
 import * as path from 'path';
 
 export class DecorationProvider {
-    private static _iconsRootPath: string = path.join(path.dirname(__dirname), '..', '..', 'resources', 'icons');
+    private static _iconsRootPath: string = path.join(path.dirname(__dirname), '..', 'resources', 'icons');
 
     public static getDecorations(statuses: Status[], isShelved: boolean): SourceControlResourceDecorations {
         const status: Status = this.getDominantStatus(statuses);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -37,6 +37,8 @@ export class Model implements Disposable {
     private _workspaceUri: Uri;
     private _config: IPerforceConfig
 
+    get workspaceUri() { return this._workspaceUri; }
+
     public get ResourceGroups(): SourceControlResourceGroup[] {
         const result: SourceControlResourceGroup[] = [];
 
@@ -203,12 +205,13 @@ export class Model implements Disposable {
         if (id.startsWith('default')) {
             const command = 'change';
             const args = '-o';
-            const uri: Uri = Uri.parse('perforce:').with({ authority: command, query: args });
+            const uri: Uri = Uri.parse('perforce:').with({ query: Utils.makePerforceUriQuery(command, args) });
             commands.executeCommand<void>("vscode.open", uri);
         } else if (id.startsWith('pending')) {
             const command = 'describe';
             const args = id.substr(id.indexOf(':') + 1);
-            const uri: Uri = Uri.parse('perforce:').with({ authority: command, query: args });
+            
+            const uri: Uri = Uri.parse('perforce:').with({ query: Utils.makePerforceUriQuery(command, args) });
             commands.executeCommand<void>("vscode.open", uri);
         }
     }
@@ -323,8 +326,8 @@ export class Model implements Disposable {
 
         let message = "Are you sure you want to revert the changes ";
         if (input instanceof Resource) {
-            file = Uri.file(input.uri.fsPath);
-            message += "to file " + Path.basename(input.uri.fsPath) + "?";
+            file = Uri.file(input.resourceUri.fsPath);
+            message += "to file " + Path.basename(input.resourceUri.fsPath) + "?";
         } else if (isResourceGroup(input)) {
             const id = input.id;
             if (id.startsWith('default')) {
@@ -401,8 +404,9 @@ export class Model implements Disposable {
             if (revert) {
                 await this.QuietlyRevertChangelist(chnum);
             }
+            Display.showMessage("Changelist shelved");
         } catch (err) {
-            Display.showError(err.toString());
+            Display.showImportantError(err.toString());
         }
         this.Refresh();
     }
@@ -417,8 +421,9 @@ export class Model implements Disposable {
         try {
             await Utils.runCommand(this._workspaceUri, command, null, null, args);
             this.Refresh();
+            Display.showMessage("Changelist unshelved");
         } catch (err) {
-            Display.showError(err.toString());
+            Display.showImportantError(err.toString());
         }
     }
 
@@ -440,41 +445,40 @@ export class Model implements Disposable {
         try {
             await Utils.runCommand(this._workspaceUri, command, null, null, args);
             this.Refresh();
+            Display.showMessage("Shelved files deleted");
         } catch (err) {
-            Display.showError(err.toString());
+            Display.showImportantError(err.toString());
         }
     }
 
     public async ShelveOrUnshelve(input: Resource): Promise<void> {
-        const file = input.uri;
 
-        if (input.status == Status.SHELVE) {
+        if (input.isShelved) {
             let args = '-c ' + input.change + ' -s ' + input.change;
             const command = 'unshelve';
-            await Utils.runCommand(this._workspaceUri, command, file, null, args).then((output) => {
+            await Utils.runCommand(this._workspaceUri, command, input.depotPath, null, args).then((output) => {
                 let args = '-d -c ' + input.change;
-                const command = 'shelve';
-                Utils.runCommand(this._workspaceUri, 'shelve', file, null, args).then((output) => {
+                Utils.runCommand(this._workspaceUri, 'shelve', input.depotPath, null, args).then((output) => {
                     Display.updateEditor();
                     Display.channel.append(output);
 
                     this.Refresh();
                 }).catch((reason) => {
-                    Display.showError(reason.toString());
+                    Display.showImportantError(reason.toString());
 
                     this.Refresh();
                 });
             }).catch((reason) => {
-                Display.showError(reason.toString());
+                Display.showImportantError(reason.toString());
             });
         }
         else {
             let args = '-f -c ' + input.change;
             const command = 'shelve';
-            await Utils.runCommand(this._workspaceUri, command, file, null, args).then((output) => {
+            await Utils.runCommand(this._workspaceUri, command, input.resourceUri, null, args).then((output) => {
                 this.Revert(input);
             }).catch((reason) => {
-                Display.showError(reason.toString());
+                Display.showImportantError(reason.toString());
             });
         }
     }
@@ -501,14 +505,14 @@ export class Model implements Disposable {
 
             for (const resource of resources) {
 
-                const file = Uri.file(resource.uri.fsPath);
+                const file = Uri.file(resource.resourceUri.fsPath);
                 const args = '-c ' + selection.id;
 
                 Utils.runCommand(_this._workspaceUri, 'reopen', file, null, args).then((output) => {
                     Display.channel.append(output);
                     _this.Refresh();
                 }).catch((reason) => {
-                    Display.showError(reason.toString());
+                    Display.showImportantError(reason.toString());
                 });
             }
         });
@@ -543,7 +547,7 @@ export class Model implements Disposable {
             Display.channel.append(output);
             this.Refresh();
         }).catch(reason => {
-            Display.showError(reason.toString());
+            Display.showImportantError(reason.toString());
         })
     }
 
@@ -614,14 +618,29 @@ export class Model implements Disposable {
                     console.log('ERROR: pending changelist already exist: ' + chnum.toString());
                 }
                 if( !config.get<boolean>('hideShelvedFiles') ) {
-                    this.getDepotShelvedFilePaths(chnum).then((value) => {
-                        if (!pendings.has(chnum)) {
-                            pendings.set(chnum, []);
+                    const depotFiles = await this.getDepotShelvedFilePaths(chnum);
+                    if (!pendings.has(chnum)) {
+                        pendings.set(chnum, []);
+                    }
+
+                    var fstatInfo = [];
+
+                    for (let i = 0; i < depotFiles.length; i += maxFilePerCommand) {
+                        fstatInfo = fstatInfo.concat(await this.getFstatInfoForFiles(depotFiles.slice(i, i + maxFilePerCommand).map(df => df[0]), '-Or'));
+                    }
+
+                    depotFiles.forEach((element, i) => {
+                        const [path, change] = element;
+
+                        let underlyingUri : Uri;
+                        let fromFile : Uri;
+                        if (fstatInfo[i]) {
+                            underlyingUri = Uri.file(fstatInfo[i]['clientFile']);
+                            fromFile = fstatInfo[i]['resolveFromFile0'] ? Uri.file(fstatInfo[i]['resolveFromFile0']) : undefined;
                         }
-                        value.forEach(element => {
-                            const resource: Resource = new Resource(this, Uri.file(element), chnum.toString(), "shelve");
-                            pendings.get(chnum).push(resource);
-                        });
+                        
+                        const resource: Resource = new Resource(this, Uri.file(path), underlyingUri, chnum.toString(), true, change, fromFile);
+                        pendings.get(chnum).push(resource);
                     });
                 }
             }
@@ -631,13 +650,15 @@ export class Model implements Disposable {
 
         const depotOpenedFilePaths = await this.getDepotOpenedFilePaths();
         for (let i = 0; i < depotOpenedFilePaths.length; i += maxFilePerCommand) {
-            const fstatInfo = await this.getFstatInfoForFiles(depotOpenedFilePaths.slice(i, i + maxFilePerCommand));
+            const fstatInfo = await this.getFstatInfoForFiles(depotOpenedFilePaths.slice(i, i + maxFilePerCommand), '-Or');
 
             fstatInfo.forEach(info => {
                 const clientFile = info['clientFile'];
                 const change = info['change'];
                 const action = info['action'];
                 const headType = info['headType'];
+                const depotPath = Uri.file(info['depotFile']);
+                const fromFile = info['resolveFromFile0'] ? Uri.file(info['resolveFromFile0']) : undefined;
                 const uri = Uri.file(clientFile);
                 if (hideNonWorksSpaceFiles) {
                     const workspaceFolder = workspace.getWorkspaceFolder(uri);
@@ -645,7 +666,7 @@ export class Model implements Disposable {
                         return
                     }
                 }
-                const resource: Resource = new Resource(this, uri, change, action, headType);
+                const resource: Resource = new Resource(this, depotPath, uri, change, false, action, fromFile, headType);
 
                 if (change.startsWith('default')) {
                     defaults.push(resource);
@@ -697,7 +718,7 @@ export class Model implements Disposable {
 
     }
 
-    private async getDepotShelvedFilePaths(chnum: number): Promise<string[]> {
+    private async getDepotShelvedFilePaths(chnum: number): Promise<[string, string][]> {
         let resource = Uri.file(this._config.localDir);
         const output = await Utils.getSimpleOutput(resource, 'describe -Ss ' + chnum);
         const shelved = output.trim().split('\n');
@@ -707,24 +728,29 @@ export class Model implements Disposable {
 
         const files = [];
         shelved.forEach(open => {
-            const matches = open.match(/(\.+)\ (.*)#(.*)/);
+            const matches = open.match(/(\.+)\ (.*)#(.*) (.*)/);
             if (matches) {
-                files.push(matches[2]);
+                files.push([matches[2], matches[4].trim()]);
             }
         });
 
         return files;
     }
 
-    private async getFstatInfoForFiles(files: string[]): Promise<any> {
+    private async getFstatInfoForFiles(files: string[], additionalParams?: string): Promise<any> {
         let resource = Uri.file(this._config.localDir);
-        const fstatOutput: string = await Utils.getSimpleOutput(resource, `fstat "${files.join('" "')}"`);
+
+        const params = additionalParams ?? '';
+
+        // a shelved file may write to stderr if it doesn't exist in the workspace - so don't complain for stderr
+        const [fstatOutput, stderr] = await Utils.getOutputs(resource, `fstat ${additionalParams} "${files.join('" "')}"`);
+
         // Windows will have lines end with \r\n.
         // Each file has multiple lines of output separated by a blank line.
         // Splitting on \n\r?\n will find newlines followed immediately by a newline
         // which will split the output for each file.
         const fstatFiles = fstatOutput.trim().split(/\n\r?\n/);
-        return fstatFiles.map((file) => {
+        const all = fstatFiles.map((file) => {
             const lines = file.split('\n');
             const lineMap = {};
             lines.forEach(line => {
@@ -738,5 +764,8 @@ export class Model implements Disposable {
             });
             return lineMap;
         });
+
+        // there may be gaps due to missing shelved files - map to the correct positions
+        return files.map((file) => all.find(fs => fs['depotFile'] === file) );
     }
 }

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -381,6 +381,21 @@ export class Model implements Disposable {
         }
     }
 
+    public async ShelveChangelist(input: SourceControlResourceGroup) : Promise<void> {
+        const id = input.id;
+        const chnum = id.substr(id.indexOf(':') + 1);
+
+        const command = 'shelve';
+        let args = '-f -c ' + chnum;
+
+        try {
+            const output = await Utils.runCommand(this._workspaceUri, command, null, null, args);
+        } catch (err) {
+            Display.showError(err.toString());
+        }
+        this.Refresh();
+    }
+
     public async ShelveOrUnshelve(input: Resource): Promise<void> {
         const file = input.uri;
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -396,6 +396,10 @@ export class Model implements Disposable {
         const id = input.id;
         const chnum = id.substr(id.indexOf(':') + 1);
 
+        if (chnum === 'default') {
+            throw new Error("Cannot shelve the default changelist");
+        }
+
         const command = 'shelve';
         const args = '-f -c ' + chnum;
 
@@ -415,6 +419,10 @@ export class Model implements Disposable {
         const id = input.id;
         const chnum = id.substr(id.indexOf(':') + 1);
 
+        if (chnum === 'default') {
+            throw new Error("Cannot unshelve the default changelist");
+        }
+
         const command = 'unshelve';
         const args = '-f -s ' + chnum + ' -c ' + chnum;
 
@@ -430,6 +438,10 @@ export class Model implements Disposable {
     public async DeleteShelvedChangelist(input: SourceControlResourceGroup) : Promise<void> {
         const id = input.id;
         const chnum = id.substr(id.indexOf(':') + 1);
+
+        if (chnum === 'default') {
+            throw new Error("Cannot delete shelved files from the default changelist");
+        }
 
         let message = "Are you sure you want to delete the shelved files from changelist " + chnum + "?";
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -381,7 +381,7 @@ export class Model implements Disposable {
         }
     }
 
-    public async ShelveChangelist(input: SourceControlResourceGroup) : Promise<void> {
+    public async ShelveChangelist(input: SourceControlResourceGroup, revert?: boolean) : Promise<void> {
         const id = input.id;
         const chnum = id.substr(id.indexOf(':') + 1);
 
@@ -389,7 +389,25 @@ export class Model implements Disposable {
         let args = '-f -c ' + chnum;
 
         try {
-            const output = await Utils.runCommand(this._workspaceUri, command, null, null, args);
+            await Utils.runCommand(this._workspaceUri, command, null, null, args);
+            if (revert) {
+                await this.Revert(input);
+            }
+        } catch (err) {
+            Display.showError(err.toString());
+        }
+        this.Refresh();
+    }
+
+    public async UnshelveChangelist(input: SourceControlResourceGroup) : Promise<void> {
+        const id = input.id;
+        const chnum = id.substr(id.indexOf(':') + 1);
+
+        const command = 'unshelve';
+        let args = '-f -s ' + chnum + ' -c ' + chnum;
+
+        try {
+            await Utils.runCommand(this._workspaceUri, command, null, null, args);
         } catch (err) {
             Display.showError(err.toString());
         }

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -676,10 +676,13 @@ export class Model implements Disposable {
 
     private async getDepotOpenedFilePaths(): Promise<string[]> {
         let resource = Uri.file(this._config.localDir);
-        const output = await Utils.getSimpleOutput(resource, 'opened');
-        const opened = output.trim().split('\n');
-        if (opened.length === 0) {
-            return;
+        let opened = [];
+        try {
+            const output = await Utils.getSimpleOutput(resource, 'opened');
+            opened = output.trim().split('\n');
+        } catch (err) {
+            // perforce writes to stderr if no files are opened.
+            console.log('ERROR: '+err);
         }
 
         const files = [];
@@ -691,6 +694,7 @@ export class Model implements Disposable {
         });
 
         return files;
+
     }
 
     private async getDepotShelvedFilePaths(chnum: number): Promise<string[]> {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -380,6 +380,15 @@ export class Model implements Disposable {
         }
     }
 
+    public async QuietlyRevertChangelist(chnum: string) : Promise<void> {
+        const command = 'revert';
+        const args = '-c ' + chnum + ' //...';
+
+        const output = await Utils.runCommand(this._workspaceUri, command, null, null, args);
+        Display.updateEditor();
+        Display.channel.append(output);
+    }
+
     public async ShelveChangelist(input: SourceControlResourceGroup, revert?: boolean) : Promise<void> {
         const id = input.id;
         const chnum = id.substr(id.indexOf(':') + 1);
@@ -390,7 +399,7 @@ export class Model implements Disposable {
         try {
             await Utils.runCommand(this._workspaceUri, command, null, null, args);
             if (revert) {
-                await this.Revert(input);
+                await this.QuietlyRevertChangelist(chnum);
             }
         } catch (err) {
             Display.showError(err.toString());

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -385,7 +385,7 @@ export class Model implements Disposable {
         const chnum = id.substr(id.indexOf(':') + 1);
 
         const command = 'shelve';
-        let args = '-f -c ' + chnum;
+        const args = '-f -c ' + chnum;
 
         try {
             await Utils.runCommand(this._workspaceUri, command, null, null, args);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -7,7 +7,6 @@ import { Status } from './Status';
 
 import * as Path from 'path';
 import * as vscode from 'vscode';
-import { fileSync } from 'tmp';
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg.id !== undefined;
@@ -404,14 +403,37 @@ export class Model implements Disposable {
         const chnum = id.substr(id.indexOf(':') + 1);
 
         const command = 'unshelve';
-        let args = '-f -s ' + chnum + ' -c ' + chnum;
+        const args = '-f -s ' + chnum + ' -c ' + chnum;
 
         try {
             await Utils.runCommand(this._workspaceUri, command, null, null, args);
+            this.Refresh();
         } catch (err) {
             Display.showError(err.toString());
         }
-        this.Refresh();
+    }
+
+    public async DeleteShelvedChangelist(input: SourceControlResourceGroup) : Promise<void> {
+        const id = input.id;
+        const chnum = id.substr(id.indexOf(':') + 1);
+
+        let message = "Are you sure you want to delete the shelved files from changelist " + chnum + "?";
+
+        const yes = "Delete Shelved Files";
+        const pick = await window.showWarningMessage(message, { modal: true }, yes);
+        if (pick !== yes) {
+            return;
+        }
+
+        const command = 'shelve';
+        let args = '-d -c '+chnum;
+
+        try {
+            await Utils.runCommand(this._workspaceUri, command, null, null, args);
+            this.Refresh();
+        } catch (err) {
+            Display.showError(err.toString());
+        }
     }
 
     public async ShelveOrUnshelve(input: Resource): Promise<void> {

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -3,7 +3,7 @@ import { DecorationProvider } from './DecorationProvider';
 import { GetStatuses, Status } from './Status';
 import { IFileType, GetFileType, FileType } from './FileTypes';
 import { Model } from './Model';
-
+import { Utils } from '../Utils';
 
 /**
  * An SCM resource represents a state of an underlying workspace resource
@@ -18,13 +18,37 @@ import { Model } from './Model';
 export class Resource implements SourceControlResourceState {
     private _statuses: Status[];
     private _headType: IFileType;
+    private _resourceUri: Uri;
 
+    /**
+     * URI is always a depot path stored as a URI (depot paths are not really URIs, but it is close enough,
+     * and the SourceControlResourceState requires this property to be a URI)
+     * You **must not** use fsPath on this URI to get a depot path - this does not work on windows.
+     * Use the `depotPath` property instead.
+     */
     get uri(): Uri { return this._uri; }
-    get resourceUri(): Uri { return this._uri; }
+    /**
+     * Resource URI *should* be the underlying file, but for shelved files, a depot path is used
+     * this keeps them together in the workspace tree, and for some operations there may not be a matching file in the workspace
+     */
+    get resourceUri(): Uri { return this._resourceUri; }
     get decorations(): SourceControlResourceDecorations {
-        // TODO Implement
-        return DecorationProvider.getDecorations(this._statuses);
+        return DecorationProvider.getDecorations(this._statuses, this._isShelved);
     }
+    /**
+     * The underlying URI is always the workspace path, where it is known, or undefined otherwise
+     */
+    get underlyingUri(): Uri | undefined { return this._underlyingUri; }
+    /**
+     * A string representation of the depot path - this is needed because, on windows, the fsPath turns into backslashes
+     */
+    get depotPath(): string { return Utils.getDepotPathFromDepotUri(this._uri); }
+    /**
+     * The file that this file is pending integration from - a depot path as a URI
+     * You **must not** use fsPath on this URI to get a depot path - this does not work on windows.
+     * Use `Utils.getDepotPathFromDepotUri` instead
+     */
+    get fromFile() : Uri | undefined { return this._fromFile; }
 
     get status(): Status {
         if (this._statuses.length > 0) {
@@ -48,9 +72,31 @@ export class Resource implements SourceControlResourceState {
         return this._change;
     }
 
-    constructor(public model: Model, private _uri: Uri, private _change: string, action: string, headType?: string) {
+    constructor(
+        public model: Model,
+        private _uri: Uri,
+        private _underlyingUri: Uri | undefined,
+        private _change: string,
+        private _isShelved: boolean,
+        action: string,
+        private _fromFile?: Uri,
+        headType?: string
+    ) {
         this._statuses = GetStatuses(action);
+        if (this._isShelved) {
+            // force a depot-like path as the resource URI, to sort them together in the tree
+            this._resourceUri = _uri;
+        } else {
+            if (!_underlyingUri) {
+                throw new Error("Files in the local workspace must have an underlying URI")
+            }
+            this._resourceUri = _underlyingUri;
+        }
         this._headType = GetFileType(headType);
+    }
+    
+    get isShelved(): boolean {
+        return this._isShelved;
     }
 
     get FileType(): IFileType {

--- a/src/scm/Status.ts
+++ b/src/scm/Status.ts
@@ -18,7 +18,6 @@ export function GetStatuses(statusText: string): Status[] {
             case "move/add": result.push(Status.MOVE_ADD); break;
             case "move/delete": result.push(Status.MOVE_DELETE); break;
             case "purge": result.push(Status.PURGE); break;
-            case "shelve": result.push(Status.SHELVE); break;
             default:
                 result.push(Status.UNKNOWN); break;
         }
@@ -39,6 +38,5 @@ export enum Status {
     MOVE_ADD,
     MOVE_DELETE,
     PURGE,
-    SHELVE,
     UNKNOWN
 }

--- a/src/test/helpers/helpers.d.ts
+++ b/src/test/helpers/helpers.d.ts
@@ -1,0 +1,13 @@
+
+
+declare module 'chai' {
+    global {
+        export namespace Chai {
+            interface Assertion {
+                vscodeOpenCall(resource : import('vscode').Uri) : void;
+                vscodeDiffCall(left : import('vscode').Uri, right : import('vscode').Uri, title : string) : void
+            }
+        }
+        
+    }
+}

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -1,0 +1,36 @@
+import { SinonSpyCall } from 'sinon'
+import * as vscode from 'vscode';
+
+function assertP4UriMatches(Assertion: Chai.AssertionStatic, got: vscode.Uri, expected: vscode.Uri, message: string)
+{
+    new Assertion(got).to.include(
+        {
+            scheme: expected.scheme,
+            path: expected.path,
+            authority: expected.authority,
+            fragment: expected.fragment
+        },
+        message
+    );
+    new Assertion(got.query).to.have.string(expected.query, message);
+}
+
+export default function (chai : Chai.ChaiStatic, utils : Chai.ChaiUtils) {
+    const Assertion = chai.Assertion;
+
+    Assertion.addMethod('vscodeOpenCall', function (resource : vscode.Uri) {
+        const obj : SinonSpyCall = this._obj as SinonSpyCall;
+
+        new Assertion(obj.args[0]).to.equal('vscode.open');
+        assertP4UriMatches(Assertion, obj.args[1], resource, "Resource");
+    });
+
+    Assertion.addMethod('vscodeDiffCall', function (left : vscode.Uri, right : vscode.Uri, title : string) {
+        const obj : SinonSpyCall = this._obj as SinonSpyCall;
+
+        new Assertion(obj.args[0]).to.equal('vscode.diff');
+        assertP4UriMatches(Assertion, obj.args[1], left, "Left Resource");
+        assertP4UriMatches(Assertion, obj.args[2], right, "Right Resource");
+        new Assertion(obj.args[3]).to.be.string(title, "Title");
+    });
+}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,0 +1,30 @@
+import * as path from 'path';
+
+import { runTests } from 'vscode-test';
+
+async function main() {
+	try {
+		// The folder containing the Extension Manifest package.json
+		// Passed to `--extensionDevelopmentPath`
+		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+
+		// The path to test runner
+		// Passed to --extensionTestsPath
+		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+
+		const testWorkspace = path.resolve(__dirname, '../../test-fixtures/core/');
+
+		// Download VS Code, unzip it and run the integration test
+		await runTests({
+			version: "insiders",
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: [testWorkspace]
+		});
+	} catch (err) {
+		console.error('Failed to run tests');
+		process.exit(1);
+	}
+}
+
+main();

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -1,0 +1,299 @@
+
+
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { PerforceService } from '../../PerforceService';
+import { Status } from '../../scm/Status';
+
+import * as path from 'path';
+import { file } from 'tmp';
+
+
+type PerforceCommand = "login" | "info" | "changes" | "opened" | "describe" | "open" | "shelve" | "unshelve" | "revert" | "fstat" | "print";
+type PerforceResponseCallback = (err: Error, stdout: string, stderr: string) => void;
+type PerforceCommandCallback = (
+    service : StubPerforceService,
+    resource?: vscode.Uri,
+    args?: string,
+    directoryOverride?: string,
+    input?: string
+) => [string, string]; // return [stdout, stderr]
+
+type PerforceResponses = Record<PerforceCommand, PerforceCommandCallback | null>;
+
+interface StubChangelist {
+    chnum : string,
+    description: string,
+    submitted?: boolean,
+    files: StubFile[],
+    shelvedFiles?: StubFile[],
+    behaviours?: StubChangelistBehaviours;
+};
+
+export interface StubFile {
+    localFile : vscode.Uri;
+    depotPath : string;
+    depotRevision: number;
+    behaviours?: StubFileBehaviours;
+    operation?: Status;
+    fileType?: string;
+    resolveFromDepotPath?: string;
+}
+
+/**
+ * Used to override / provide behaviour for a specific changelist or file
+ * NOTE That the base response function must support this by parsing for the specified
+ * changelist / file and calling the override function instead - this will not necessarily
+ * work for all commands
+ */
+type StubBehaviours = Partial<PerforceResponses>;
+type StubFileBehaviours = Exclude<StubBehaviours, "login" | "info" | "describe">;
+type StubChangelistBehaviours = Exclude<StubBehaviours, "login" | "info" | "open" | "print">;
+
+function stdout(out : string) : [string, string] {
+    return [out, ""];
+}
+
+function stderr(err : string) : [string, string] {
+    return ["", err];
+}
+
+export function returnStdOut (out: string) {
+    return () => stdout(out);
+}
+
+export function returnStdErr (err: string) {
+    return () => stderr(err);
+}
+
+function getDepotPathAndOp(f : StubFile, withHyphen : boolean) {
+    return f.depotPath + "#" + f.depotRevision + " " + (withHyphen ? "- " : "") +getStatusText(f.operation ?? Status.EDIT);
+}
+
+function getStatusText(status : Status) : string {
+    switch (status) {
+        case Status.ADD: return "add";
+        case Status.ARCHIVE: return "archive";
+        case Status.BRANCH: return "branch";
+        case Status.DELETE: return "delete";
+        case Status.EDIT: return "edit";
+        case Status.IMPORT: return "import";
+        case Status.INTEGRATE: return "integrate";
+        case Status.LOCK: return "lock";
+        case Status.MOVE_ADD: return "move/add";
+        case Status.MOVE_DELETE: return "move/delete";
+        case Status.PURGE: return "purge";
+        case Status.UNKNOWN: return "???";
+    }
+}
+
+export const makeResponses = (responses?: Partial<PerforceResponses>, from? : PerforceResponses) => {
+    const ret : PerforceResponses = from ? from : {
+        "login": returnStdOut("'login' not necessary, no password set for this user."),
+        "info": (service, resource) => {
+            const ret =
+                "User name: user\n"+
+                "Client name: cli\n"+
+                "Client host: localhost\n"+
+                "Client root: "+resource.fsPath+"\n"+
+                "Current directory: "+resource.fsPath+"\n"+
+                "Peer address: 127.0.0.1:54954\n"+
+                "Client address: 127.0.0.1\n"+
+                "Server address: kubernetes.docker.internal:1666\n"+
+                "Server root: C:\Program Files\Perforce\Server\n"+
+                "Server date: 2019/12/30 15:22:41 +0000 GMT Standard Time\n"+
+                "Server uptime: 16:09:09\n"+
+                "Server version: P4D/NTX64/2019.1/1876401 (2019/10/30)\n"+
+                "Server license: none\n"+
+                "Case Handling: insensitive\n"
+    
+            return stdout(ret);
+        },
+        "changes": (service) => {
+            const ret = service.changelists
+                .filter(c => !c.submitted && c.chnum !== "default")
+                .map(c => `Change ${c.chnum} on 2019/12/25 by user@cli *pending* '${c.description}'`)
+                .join("\n");
+            return stdout(ret);
+        },
+        "opened": (service, resource, args) => {
+            if (args) {
+                throw new Error("'opened' with args not implemented");
+            } else {
+                const ret = service.changelists
+                    .filter(c => !c.submitted)
+                    .map(c => {
+                        return c.files
+                            .map(f => getDepotPathAndOp(f, true) + " change "+ c.chnum +" (" + (f.fileType ?? "text") + ")")
+                            .join("\n")
+                    })
+                    .join("\n");
+                return stdout(ret);
+            }
+        },
+        "describe": (service, resource, args, ...rest) => {
+            const chnum = args.split(" ")[1];
+            const c = service.changelists.find((c) => c.chnum === chnum);
+            if (c && c.behaviours?.describe) {
+                c.behaviours.describe(service, resource, args, ...rest);
+            } else if (c) {
+                const pend = c.submitted ? " *pending*" : ""; 
+                let ret =
+                    "Change "+chnum+" by user@cli on 2019/12/25 10:36:29"+pend+"\n\n"+
+                    "       "+c.description+"\n\n"+
+                    (c.submitted ? "Affected files ...\n" : "Shelved files ...\n\n");
+
+                if (c.shelvedFiles) {
+                    ret += c.shelvedFiles.map(f => "... " + getDepotPathAndOp(f, false)).join("\n");
+                }
+                    //... //depot/TestArea/doc3.txt#1 add
+                    //... //depot/TestArea/hmm#1 add
+                    //... //depot/TestArea/My initial text document.txt#2 edit
+                    //... //depot/TestArea/my next document.txt#1 delete
+                return stdout(ret);
+            } else {
+                return stderr(c + " - no such changelist");
+            }
+        },
+        "open": () => {
+            return stdout("open not implemented");
+        },
+        "shelve": (service, ...rest) => {
+            const ret = service.runChangelistBehaviour("shelve", "c", ...rest);
+            return ret ?? stdout("shelve not implemented");
+        },
+        "unshelve": (service, ...rest) => {
+            const ret = service.runChangelistBehaviour("unshelve", "s", ...rest);
+            return ret ?? stdout("unshelve not implemented");
+        },
+        "revert": (service, ...rest) => {
+            const ret = service.runChangelistBehaviour("revert", "c", ...rest);
+            return ret ?? stdout("revert not implemented");
+        },
+        "fstat": (service, resource, args, ...rest) => {
+            const [, ...files] = args.split(" ");
+            // remove quotes
+            const fs = files.map(f => service.getFstatOutput(f.slice(1, -1)));
+            const stdout : string[] = [];
+            const stderr : string[] = [];
+            fs.forEach((text, i) => {
+                if (text !== undefined) {
+                    stdout.push(text);
+                } else {
+                    stderr.push(files[i] + " - no such file(s).");
+                }
+            });
+            return [stdout.join("\n\n"), stderr.join("\n\n")];
+        },
+        "print": returnStdOut("print not implemented")
+    }
+    if (responses) {
+        Object.keys(responses).forEach(key => {
+            ret[key] = responses[key];
+        });
+    }
+    return ret;
+}
+
+export function getLocalFile(workspace : vscode.Uri, ...relativePath : string[]) {
+    return vscode.Uri.file(path.resolve(workspace.fsPath, ...relativePath));
+}
+
+export class StubPerforceService {
+    public changelists : StubChangelist[];
+
+    constructor(private _responses?: PerforceResponses) {
+        this.changelists = [];
+        if (!_responses) {
+            this._responses = makeResponses();
+        }
+    }
+
+    setResponse(command : PerforceCommand, response: PerforceCommandCallback | null)
+    {
+        this._responses[command] = response;
+    }
+
+    with(responses : Partial<PerforceResponses>) {
+        const res : PerforceResponses = makeResponses(responses, this._responses);
+        return new StubPerforceService(res);
+    }
+
+    stubExecute() {
+        return sinon.stub(PerforceService, "execute").callsFake(this.execute.bind(this));
+    }
+
+    runChangelistBehaviour(
+        command: string,
+        identifier: string,
+        resource: vscode.Uri,
+        args?: string,
+        directoryOverride?: string,
+        input?: string
+    ) : [string, string] | undefined
+    {
+        const re = new RegExp(`-${identifier} (\\w*)`)
+        const matches = args.match(re);
+        const chnum = matches?.[1];
+        if (chnum) {
+            const c = this.getChangelist(chnum);
+            if (c?.behaviours?.[command]) {
+                return c.behaviours[command](this, resource, args, directoryOverride, input);
+            }
+        }
+        return undefined;
+    }
+
+    execute(
+        resource: vscode.Uri,
+        command: string,
+        responseCallback: PerforceResponseCallback,
+        args?: string,
+        directoryOverride?: string,
+        input?: string
+    )
+    {
+        const [cmd, ...firstArgs] = command.split(" ");
+        const allArgs = firstArgs?.length > 0 ?
+                firstArgs.join(" ") + (args ? " " + args : "") :
+                args;
+        const func = this._responses[cmd];
+        if (!func) {
+            throw new Error("No stub for perforce command: "+cmd);
+        }
+        const ret = func(this, resource, allArgs, directoryOverride, input);
+        setTimeout(() => {
+            responseCallback(undefined, ret[0], ret[1]);
+        }, 0);
+    }
+
+    getChangelist(chnum: string) {
+        return this.changelists.find(c => c.chnum === chnum);
+    }
+
+    getFstatOutput(depotPath: string) : string | undefined {
+        const cl : StubChangelist = this.changelists.find(c => c.files.find(file => file.depotPath === depotPath) || c.shelvedFiles?.find(file => file.depotPath === depotPath));
+        const pendingFile = cl?.files.find(file => file.depotPath === depotPath);
+        const shelvedFile = cl?.files.find(file => file.depotPath === depotPath)
+        
+        if (pendingFile || shelvedFile) {
+            const props = {
+                depotFile: depotPath,
+                clientFile: pendingFile?.localFile.fsPath ?? shelvedFile?.localFile.fsPath,
+                isMapped: true,
+                headType: pendingFile?.fileType ?? shelvedFile?.fileType ?? "text",
+                action: pendingFile ? getStatusText(pendingFile.operation ?? Status.EDIT) : false,
+                change: pendingFile ? cl.chnum : false,
+                resolveFromFile0: pendingFile?.resolveFromDepotPath ?? shelvedFile?.resolveFromDepotPath
+            }
+            return Object.keys(props).filter(prop => props[prop] !== undefined && props[prop] !== false).map(prop => {
+                if (typeof props[prop] === "string") { 
+                    return `... ${prop} ${props[prop]}`
+                } else {
+                    return `... ${prop}`
+                }
+            }).join("\n");
+        }
+    }
+}

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
+
+export function run(): Promise<void> {
+	// Create the mocha test
+	const mocha = new Mocha({
+		ui: 'bdd',
+	});
+	mocha.useColors(true);
+
+	const testsRoot = path.resolve(__dirname, '..');
+
+	return new Promise((c, e) => {
+		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+			if (err) {
+				return e(err);
+			}
+
+			// Add files to the test suite
+			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+			try {
+				// Run the mocha test
+				mocha.run(failures => {
+					if (failures > 0) {
+						e(new Error(`${failures} tests failed.`));
+					} else {
+						c();
+					}
+				});
+			} catch (err) {
+				e(err);
+			}
+		});
+	});
+}

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1,0 +1,471 @@
+import {expect} from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinonChai from 'sinon-chai';
+
+import * as vscode from 'vscode';
+
+import * as sinon from 'sinon';
+import { IPerforceConfig } from '../../PerforceService';
+import { PerforceSCMProvider } from '../../ScmProvider';
+import { PerforceContentProvider } from '../../ContentProvider';
+import { StubPerforceService, StubFile, getLocalFile, returnStdErr, returnStdOut } from './StubPerforceService';
+import { Display } from '../../Display';
+import { Utils } from '../../Utils';
+import * as path from 'path';
+import { Resource } from '../../scm/Resource';
+import { Status } from '../../scm/Status';
+import p4Commands from '../helpers/p4Commands';
+
+chai.use(sinonChai);
+chai.use(p4Commands);
+chai.use(chaiAsPromised);
+
+interface TestItems {
+    instance : PerforceSCMProvider;
+    stubService : StubPerforceService;
+    execute : sinon.SinonStub;
+    showMessage : sinon.SinonSpy;
+    showError : sinon.SinonSpy;
+    showImportantError : sinon.SinonSpy;
+    refresh: sinon.SinonSpy;
+}
+
+describe('Model & ScmProvider modules', () => {
+    const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
+    const config : IPerforceConfig ={
+        localDir: workspaceUri.fsPath,
+        p4Client: "cli",
+        p4User: "user"
+    };
+
+    let items : TestItems;
+    let subscriptions: vscode.Disposable[] = [];
+    
+    const doc = new PerforceContentProvider("perforce");
+
+    before(async() => {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+    after(() => {
+        doc.dispose();
+    })
+    beforeEach(async () => {
+
+        const showMessage = sinon.spy(Display, "showMessage");
+        const showError = sinon.spy(Display, "showError");
+
+        const stubService = new StubPerforceService();
+        stubService.changelists = [
+            {
+                chnum: "1",
+                description: "Changelist 1",
+                files: [
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'a.txt'),
+                        depotPath: "//depot/testArea/testFolder/a.txt",
+                        depotRevision: 1,
+                        operation: Status.EDIT
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'deleted.txt'),
+                        depotPath: "//depot/testArea/testFolder/deleted.txt",
+                        depotRevision: 2,
+                        operation: Status.DELETE
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'new.txt'),
+                        depotPath: "//depot/testArea/testFolder/new.txt",
+                        depotRevision: 3,
+                        operation: Status.ADD
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'moved.txt'),
+                        depotPath: "//depot/testArea/testFolder/moved.txt",
+                        depotRevision: 1,
+                        operation: Status.MOVE_ADD,
+                        resolveFromDepotPath: "//depot/testArea/testFolderOld/movedFrom.txt"
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolderOld', 'movedFrom.txt'),
+                        depotPath: "//depot/testArea/testFolderOld/movedFrom.txt",
+                        depotRevision: 3,
+                        operation: Status.MOVE_DELETE
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'branched.txt'),
+                        depotPath: "//depot/testArea/testFolder/branched.txt",
+                        depotRevision: 1,
+                        operation: Status.BRANCH,
+                        resolveFromDepotPath: "//depot/testAreaOld/testFolder/branchedFrom.txt"
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'integrated.txt'),
+                        depotPath: "//depot/testArea/testFolder/integrated.txt",
+                        depotRevision: 7,
+                        operation: Status.INTEGRATE,
+                        resolveFromDepotPath: "//depot/testAreaOld/testFolder/integrated.txt"
+                    },
+                ],
+                shelvedFiles: [
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'a.txt'),
+                        depotPath: "//depot/testArea/testFolder/a.txt",
+                        depotRevision: 1,
+                        operation: Status.EDIT
+                    },
+                    {
+                        localFile: getLocalFile(workspaceUri, 'testFolder', 'deleted.txt'),
+                        depotPath: "//depot/testArea/testFolder/deleted.txt",
+                        depotRevision: 2,
+                        operation: Status.DELETE
+                    }
+                ]
+            },
+            {
+                chnum: "2",
+                description: "Changelist 2",
+                files: [],
+                behaviours: {
+                    "shelve": returnStdErr("my shelve error"),
+                    "unshelve": returnStdErr("my unshelve error")
+                }
+            },
+            {
+                chnum: "3",
+                description: "Changelist 3",
+                submitted: true,
+                files: []
+            }
+        ];
+        const execute = stubService.stubExecute();
+
+        const instance = new PerforceSCMProvider(config, workspaceUri, "perforce");
+        subscriptions.push(instance);
+        const showImportantError = sinon.spy(Display, "showImportantError");
+
+        const promise = new Promise((res, rej) => {
+            subscriptions.push(instance.onDidChange((e) => {
+                res();
+            }));
+        });
+
+        const refresh = sinon.spy();
+
+        items = {
+            stubService,
+            instance,
+            execute,
+            showMessage,
+            showError,
+            showImportantError,
+            refresh
+        }
+
+        await promise;
+
+        subscriptions.push(instance.onDidChange(refresh));
+
+    });
+    afterEach(async () => {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        subscriptions.forEach(sub => sub.dispose());
+        subscriptions = [];
+        sinon.restore();
+    });
+
+    describe('Shelving a changelist', () => {
+        it('Cannot shelve the default changelist', async () => {
+            await expect(PerforceSCMProvider.ShelveChangelist(items.instance.resources[0])).to.eventually.be.rejectedWith("Cannot shelve the default changelist");
+            expect(items.execute).not.to.have.been.calledWithMatch(workspaceUri, "shelve");
+            expect(items.refresh).not.to.have.been.called;
+        });
+
+        it('Can shelve a valid Changelist', async () => {
+            await PerforceSCMProvider.ShelveChangelist(items.instance.resources[1]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-f -c 1");
+            expect(items.showMessage).to.have.been.calledOnceWith("Changelist shelved");
+            expect(items.refresh).to.have.been.calledOnce;
+        });
+
+        it('Can shelve and revert a valid changelist', async () => {
+            await PerforceSCMProvider.ShelveRevertChangelist(items.instance.resources[1]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-f -c 1");
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "revert", sinon.match.any, "-c 1 //...");
+            expect(items.showMessage).to.have.been.calledOnceWith("Changelist shelved");
+            expect(items.refresh).to.have.been.calledOnce;
+        });
+
+        it('Can handle an error when shelving a changelist', async () => {
+            await PerforceSCMProvider.ShelveChangelist(items.instance.resources[2]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-f -c 2");
+            expect(items.showMessage).not.to.have.been.called;
+            expect(items.showImportantError).to.have.been.calledOnceWith("my shelve error");
+            expect(items.refresh).to.have.been.calledOnce;
+        });
+    
+        it('Can handle an error when shelving and reverting a changelist', async () => {
+            await PerforceSCMProvider.ShelveRevertChangelist(items.instance.resources[2]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-f -c 2");
+            expect(items.showMessage).not.to.have.been.called;
+            expect(items.showImportantError).to.have.been.calledOnceWith("my shelve error");
+            expect(items.execute).not.to.have.been.calledWithMatch(workspaceUri, "revert");
+            expect(items.refresh).to.have.been.calledOnce;
+        });
+    });
+
+    describe('Unshelving a changelist', () => {
+        it('Can unshelve a valid Changelist', async () => {
+            await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[1]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "unshelve", sinon.match.any, "-f -s 1");
+            expect(items.showMessage).to.have.been.calledOnceWith("Changelist unshelved");
+            expect(items.refresh).to.have.been.calledOnce;
+        });
+
+        it('Cannot unshelve default changelist', async () => {
+            await expect(PerforceSCMProvider.UnshelveChangelist(items.instance.resources[0])).to.eventually.be.rejectedWith("Cannot unshelve the default changelist");
+            expect(items.execute).not.to.have.been.calledWithMatch(workspaceUri, "unshelve");
+            expect(items.refresh).not.to.have.been.called;
+        });
+
+        it('Can handle an error when unshelving a changelist', async () => {
+            await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[2]);
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "unshelve", sinon.match.any, "-f -s 2 -c 2");
+            expect(items.showMessage).not.to.have.been.called;
+            expect(items.showImportantError).to.have.been.calledOnceWith("my unshelve error");
+            expect(items.refresh).not.to.have.been.called;
+        });
+    });
+
+    describe('Deleting a shelve', () => {
+        it ('Deletes a shelved changelist', async() => {
+            // accept the warning
+            const warn = sinon.stub(vscode.window, "showWarningMessage").resolvesArg(2);
+
+            await PerforceSCMProvider.DeleteShelvedChangelist(items.instance.resources[1]);
+            
+            expect(warn).to.have.been.calledOnce;
+            expect(items.refresh).to.have.been.calledOnce;
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-d -c 1");
+        });
+
+        it ('Can cancel deleting a shelved changelist', async() => {
+            // close the warning without accepting
+            const warn = sinon.stub(vscode.window, "showWarningMessage").resolves(undefined);
+
+            await PerforceSCMProvider.DeleteShelvedChangelist(items.instance.resources[1]);
+            
+            expect(warn).to.have.been.calledOnce;
+            expect(items.refresh).not.to.have.been.called;
+            expect(items.execute).not.to.have.been.calledWithMatch(workspaceUri, "shelve");
+        });
+
+        it ('Can handle an error when deleting a shelved changelist', async() => {
+            // accept the warning
+            const warn = sinon.stub(vscode.window, "showWarningMessage").resolvesArg(2);
+
+            await PerforceSCMProvider.DeleteShelvedChangelist(items.instance.resources[2]);
+            
+            expect(warn).to.have.been.calledOnce;
+            expect(items.execute).to.have.been.calledWithMatch(workspaceUri, "shelve", sinon.match.any, "-d -c 2");
+            expect(items.showImportantError).to.have.been.calledOnceWith("my shelve error");
+            expect(items.refresh).not.to.have.been.called;
+        });
+
+        it('Cannot delete from the default changelist', async () => {
+            await expect(PerforceSCMProvider.DeleteShelvedChangelist(items.instance.resources[0])).to.eventually.be.rejectedWith("Cannot delete shelved files from the default changelist");
+            expect(items.execute).not.to.have.been.calledWithMatch(workspaceUri, "shelve");
+            expect(items.refresh).not.to.have.been.called;
+        });
+
+    });
+
+    describe('Opening', () => {
+
+        function findResourceForShelvedFile(group: vscode.SourceControlResourceGroup, file: StubFile) {
+            return group.resourceStates.find(resource => (resource as Resource).isShelved && Utils.getDepotPathFromDepotUri(resource.resourceUri) === file.depotPath)
+        }
+
+        function findResourceForFile(group: vscode.SourceControlResourceGroup, file: StubFile) {
+            return group.resourceStates.find(resource => !(resource as Resource).isShelved && (resource as Resource).resourceUri.fsPath === file.localFile.fsPath)
+        }
+
+        /**
+         * Matches against a perforce URI, containing a local file's path
+         * @param file 
+         */
+        function perforceLocalUriMatcher(file: StubFile){
+            return Utils.makePerforceDocUri(file.localFile, "print", "-q", {workspace: workspaceUri.fsPath});
+        }
+
+        /**
+         * Matches against a perforce URI, using the depot path for a file
+         * @param file 
+         */
+        function perforceDepotUriMatcher(file: StubFile) {
+            return Utils.makePerforceDocUri(vscode.Uri.parse('perforce:' + file.depotPath), "print", "-q", {depot:  true, workspace: workspaceUri.fsPath});
+        }
+
+        /**
+         * Matches against a perforce URI, using the resolvedFromFile0 depot path
+         * @param file 
+         */
+        function perforceFromFileUriMatcher(file: StubFile){
+            return Utils.makePerforceDocUri(vscode.Uri.parse('perforce:' + file.resolveFromDepotPath), "print", "-q", {depot:  true, workspace: workspaceUri.fsPath});
+        }
+
+        /**
+         * Matches against a perforce URI, using the depot path for the file AND containing a fragment for the shelved changelist number
+         * @param file
+         * @param chnum 
+         */
+        function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
+            return Utils.makePerforceDocUri(vscode.Uri.parse('perforce:' + file.depotPath).with({fragment: "@="+chnum}), "print", "-q", {depot:  true, workspace: workspaceUri.fsPath});
+        }
+
+        function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
+            return Utils.makePerforceDocUri(file.localFile.with({fragment: "@="+chnum}), "print", "-q", {workspace: workspaceUri.fsPath});
+        }
+
+        let execCommand : sinon.SinonSpy;
+        beforeEach(() => {
+            execCommand = sinon.spy(vscode.commands, "executeCommand");
+        });
+
+        function getCall(command: sinon.SinonSpy, index: number) {
+            return command.getCalls()[index >= 0 ? index : command.getCalls().length+index];
+        }
+
+        describe('When opening a file', () => {
+            it('Opens the underlying workspace file', () => {
+                const file = items.stubService.changelists[0].files[0];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                PerforceSCMProvider.OpenFile(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeOpenCall(file.localFile);
+            });
+            it ('Can open multiple files', () => {
+                const file1 = items.stubService.changelists[0].files[0];
+                const resource1 = findResourceForFile(items.instance.resources[1], file1);
+
+                const file2 = items.stubService.changelists[0].files[2];
+                const resource2 = findResourceForFile(items.instance.resources[1], file2);
+
+                PerforceSCMProvider.OpenFile(resource1, resource2);
+                expect(getCall(execCommand, -2)).to.be.vscodeOpenCall(file1.localFile);
+                expect(execCommand.lastCall).to.be.vscodeOpenCall(file2.localFile);
+            });
+        });
+        describe('When opening an scm resource', () => {
+            it('Diffs a local file against the depot file', async () => {;
+                const file = items.stubService.changelists[0].files[0];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceLocalUriMatcher(file), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+                expect(items.execute).to.be.calledWithMatch(file.localFile, 'print', sinon.match.any, '-q "'+file.localFile.fsPath+'"');
+            });
+            it('Can open multiple resources', async () => {
+                const file1 = items.stubService.changelists[0].files[0];
+                const resource1 = findResourceForFile(items.instance.resources[1], file1);
+
+                const file2 = items.stubService.changelists[0].files[1];
+                const resource2 = findResourceForFile(items.instance.resources[1], file2);
+
+                await PerforceSCMProvider.Open(resource1, resource2);
+                expect(getCall(execCommand, -2)).to.be.vscodeDiffCall(perforceLocalUriMatcher(file1), file1.localFile, path.basename(file1.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+                expect(items.execute).to.be.calledWithMatch(file1.localFile, 'print', sinon.match.any, '-q "'+file1.localFile.fsPath+'"');
+                expect(execCommand.lastCall).to.be.vscodeOpenCall(perforceLocalUriMatcher(file2));
+            });
+            it('Displays the depot version of a deleted file', () => {
+                const file = items.stubService.changelists[0].files[1];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeOpenCall(perforceLocalUriMatcher(file));
+            });
+            it('Diffs a new file against an empty file', () => {
+                const file = items.stubService.changelists[0].files[2];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(vscode.Uri.parse("perforce:EMPTY"), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+            });
+            it('Diffs a moved file against the original file', async () => {
+                const file = items.stubService.changelists[0].files[3];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceFromFileUriMatcher(file), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+                expect(items.execute).to.be.calledWithMatch(sinon.match({fsPath: workspaceUri.fsPath}), 'print', sinon.match.any, '-q "'+file.resolveFromDepotPath+'"');
+            });
+            it('Displays the depot version for a move / delete', () => {
+                const file = items.stubService.changelists[0].files[4];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                PerforceSCMProvider.Open(resource);
+
+            });
+            it('Diffs a file opened for branch against an empty file', () => {
+                const file = items.stubService.changelists[0].files[5];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(vscode.Uri.parse("perforce:EMPTY"), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+            });
+            it('Diffs an integration/merge against the target depot file', async () => {
+                const file = items.stubService.changelists[0].files[6];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceLocalUriMatcher(file), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+
+                expect(items.execute).to.be.calledWithMatch(file.localFile, 'print', sinon.match.any, '-q "'+file.localFile.fsPath+'"');
+            });
+            it('Diffs a shelved file against the depot file', async () => {
+                const file = items.stubService.changelists[0].shelvedFiles[0];
+                const resource = findResourceForShelvedFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceDepotUriMatcher(file), perforceShelvedUriMatcher(file, "1"), path.basename(file.localFile.path) + " - Diff Shelve (right) Against Depot Version (left)");
+                expect(items.execute).to.be.calledWithMatch({fsPath: workspaceUri.fsPath}, 'print', sinon.match.any, '-q "'+file.depotPath+'@=1"');
+                expect(items.execute).to.be.calledWithMatch({fsPath: workspaceUri.fsPath}, 'print', sinon.match.any, '-q "'+file.depotPath+'"');
+            });
+            it('Can diff a local file against the shelved file (from the shelved file)', async() => {
+                const file = items.stubService.changelists[0].shelvedFiles[0];
+                const resource = findResourceForShelvedFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.OpenvShelved(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceShelvedUriMatcher(file, "1"), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Shelved Version (left)");
+                expect(items.execute).to.be.calledWithMatch({fsPath: workspaceUri.fsPath}, 'print', sinon.match.any, '-q "'+file.depotPath+'@=1"');
+            });
+            it('Can diff a local file against the shelved file (from the local file)', async() => {
+                const file = items.stubService.changelists[0].files[0];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.OpenvShelved(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(perforceLocalShelvedUriMatcher(file, "1"), file.localFile, path.basename(file.localFile.path) + " - Diff Workspace (right) Against Shelved Version (left)");
+                expect(items.execute).to.be.calledWithMatch(file.localFile, 'print', sinon.match.any, '-q "'+file.localFile.fsPath+'@=1"');
+            });
+            it('Displays the depot version for a shelved deletion', async () => {
+                const file = items.stubService.changelists[0].files[1];
+                const resource = findResourceForFile(items.instance.resources[1], file);
+
+                await PerforceSCMProvider.Open(resource);
+
+                expect(execCommand.lastCall).to.be.vscodeOpenCall(perforceLocalUriMatcher(file));
+            });
+        });
+    });
+
+});

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -332,10 +332,6 @@ describe('Model & ScmProvider modules', () => {
             execCommand = sinon.spy(vscode.commands, "executeCommand");
         });
 
-        function getCall(command: sinon.SinonSpy, index: number) {
-            return command.getCalls()[index >= 0 ? index : command.getCalls().length+index];
-        }
-
         describe('When opening a file', () => {
             it('Opens the underlying workspace file', () => {
                 const file = items.stubService.changelists[0].files[0];
@@ -353,7 +349,7 @@ describe('Model & ScmProvider modules', () => {
                 const resource2 = findResourceForFile(items.instance.resources[1], file2);
 
                 PerforceSCMProvider.OpenFile(resource1, resource2);
-                expect(getCall(execCommand, -2)).to.be.vscodeOpenCall(file1.localFile);
+                expect(execCommand.getCall(-2)).to.be.vscodeOpenCall(file1.localFile);
                 expect(execCommand.lastCall).to.be.vscodeOpenCall(file2.localFile);
             });
         });
@@ -375,7 +371,7 @@ describe('Model & ScmProvider modules', () => {
                 const resource2 = findResourceForFile(items.instance.resources[1], file2);
 
                 await PerforceSCMProvider.Open(resource1, resource2);
-                expect(getCall(execCommand, -2)).to.be.vscodeDiffCall(perforceLocalUriMatcher(file1), file1.localFile, path.basename(file1.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
+                expect(execCommand.getCall(-2)).to.be.vscodeDiffCall(perforceLocalUriMatcher(file1), file1.localFile, path.basename(file1.localFile.path) + " - Diff Workspace (right) Against Most Recent Revision (left)");
                 expect(items.execute).to.be.calledWithMatch(file1.localFile, 'print', sinon.match.any, '-q "'+file1.localFile.fsPath+'"');
                 expect(execCommand.lastCall).to.be.vscodeOpenCall(perforceLocalUriMatcher(file2));
             });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,0 +1,39 @@
+import {expect} from 'chai';
+
+import * as vscode from 'vscode';
+
+import {Utils} from '../../Utils';
+import { utils } from 'mocha';
+
+
+describe('Utils module', () => {
+    describe('Perforce Uris', () => {
+        const depotPath = "//depot/my/path/file.txt";
+        const depotUri = vscode.Uri.file(depotPath);
+
+        it('Can determine a valid path from a Uri', () => {
+            expect(Utils.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
+        });
+        it('Can encode and decode a URI Query', () => {
+            const query = Utils.makePerforceUriQuery('print', '-q', {depot: true, nothing: false, stringArg: "s&t=uff"});
+            expect(query).to.equal("p4args=-q&command=print&depot&stringArg=s%26t%3Duff");
+
+            const decoded = Utils.decodeUriQuery(query);
+            expect(decoded).to.deep.equal({p4args: "-q", command: "print", depot: true, stringArg: "s&t=uff"});
+        });
+        it('Can make a full perforce doc URI', () => {
+            const uri = Utils.makePerforceDocUri(depotUri, 'print', '-q', {depot: true});
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.authority).to.equal("depot");
+            expect(uri.query).to.equal("p4args=-q&command=print&depot");
+        });
+    });
+    describe('Path expansion', () => {
+        it('Escapes special characters', () => { 
+            const path = "AFile%*#@.txt";
+            expect(Utils.expansePath(path)).to.equal("AFile%25%2A%23%40.txt");
+        });
+        // TODO local dir settings (what is this for?)
+    });
+});
+

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "perforce.client": "",
+    "perforce.user": ""
+}

--- a/test-fixtures/core/testFolder/a.txt
+++ b/test-fixtures/core/testFolder/a.txt
@@ -1,0 +1,1 @@
+A Content

--- a/test-fixtures/core/testFolder/branched.txt
+++ b/test-fixtures/core/testFolder/branched.txt
@@ -1,0 +1,1 @@
+a file that has been branched from somewhere else!

--- a/test-fixtures/core/testFolder/integrated.txt
+++ b/test-fixtures/core/testFolder/integrated.txt
@@ -1,0 +1,2 @@
+a file with some integrated content
+that may have been manually merged.

--- a/test-fixtures/core/testFolder/moved.txt
+++ b/test-fixtures/core/testFolder/moved.txt
@@ -1,0 +1,1 @@
+a file that has been moved from somewhere else

--- a/test-fixtures/core/testFolder/new.txt
+++ b/test-fixtures/core/testFolder/new.txt
@@ -1,0 +1,1 @@
+a new file

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "lib": [
             "es6"
         ],
-        "outDir": "out/src",
+        "outDir": "out",
         "sourceMap": true
     },
     "exclude": [


### PR DESCRIPTION
On our team, the typical workflow for a story, is that each developer will take a task, and we will shelve the changelist when we need to share code and test items together.

This means that our typical usage for shelving is to shelve the entire changelist without reverting any of the files, finally, after the code review we delete the shelved files and submit the changelist.

I've developed these changes on the basis of how we work, but I understand this may be different for different users, so open to comments on whether this is the right general approach.

This change adds four new context items for a changelist:
![Annotation 2019-11-30 181430](https://user-images.githubusercontent.com/49367953/69904325-4e240c80-139d-11ea-999c-ba264ee28b26.png)

* Shelve changelist - Shelves the whole changelist with p4 shelve -f without reverting files
* Shelve and revert changelist - Shelves the whole changelist with p4 shelve -f and reverts the files (assuming shelving was successful) without prompting. Does not attempt to delete the changelist (as with the existing revert option)
* Unshelve changelist - Unshelves all of the files from the changelist using p4 unshelve -f. This will clobber writable files that are not already open, but IIRC there may be cases where resolve is required for open files.
* Delete shelved files - Prompts the user for confirmation and then deletes all of the files from the shelved changelist


additionally, it fixes an issue where shelved files were not visible in any changelists, unless you had at least one file open for edit (not shelved).