### PR TITLE
fix executeCommand in PerforceService.ts

### DIFF
--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -169,7 +169,7 @@ export namespace PerforceService {
         });
     }
 
-    function execCommand(resource: Uri, command: string, responseCallback: (err: Error, stdout: string, stderr: string) => void, args?: string, directoryOverride?: string, input?: string): void {
+    function execCommand(resource: Uri, command: string, responseCallback: (err: Error, stdout: string, stderr: string) => void, args?: string, directoryOverride?: string, input?: string, onDone?: () => void): void {
         const wksFolder = workspace.getWorkspaceFolder(resource);
         const config = wksFolder ? getConfig(wksFolder.uri.fsPath) : null;
         const wksPath = wksFolder ? wksFolder.uri.fsPath : '';
@@ -196,6 +196,7 @@ export namespace PerforceService {
         if (input != null) {
             child.stdin.end(input, 'utf8');
         }
+        if(onDone) child.on('close', onDone);
     }
 
     export function handleInfoServiceResponse(err: Error, stdout: string, stderr: string) {


### PR DESCRIPTION
The last parameter must be a callback and call it when passing it as a parameter of 'limiter.submit', or it won't work as expect.

> When using submit(), make sure all the jobs will eventually complete by calling their callback, or set an expiration. Even if you submitted your job with a null callback , it still needs to call its callback. This is particularly important if you are using a maxConcurrent value that isn't null (unlimited), otherwise those not completed jobs will be clogging up the limiter and no new jobs will be allowed to run. It's safe to call the callback more than once, subsequent calls are ignored.